### PR TITLE
S0S-057 refactor realtime update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ The fastest way to make some sound emanate from your device is with the SimpleAu
 
 Add the following to your build.sbt file:
 
+For Documentation and Examples see: [Sounds of Scala](https://pauliamgiant.github.io/sounds-of-scala/)
+
 ```scala 3
-libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.5.1"
+libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0"
 ```
 Then in the code of your Scala.js project pass the path to an audio file to the SimpleAudioPlayer constructor.
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(
   List(
-    tlBaseVersion := "0.5",
+    tlBaseVersion := "0.7",
     startYear := Some(2024),
     licenses := Seq(License.Apache2),
     organization := "org.soundsofscala",

--- a/docs/src/pages/README.md
+++ b/docs/src/pages/README.md
@@ -8,7 +8,7 @@ Sounds of Scala is available for Scala 3.2+. You can add Sounds of Scala to your
 
 ```scala 3
 libraryDependencies ++= Seq(
-  "org.soundsofscala" %%% "sounds-of-scala" % "0.4.0")
+  "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0")
 ```
 
 ### [Next Step: Getting Started](http://127.0.0.1:4242/getting-started/)

--- a/docs/src/pages/getting-started/README.md
+++ b/docs/src/pages/getting-started/README.md
@@ -49,28 +49,26 @@ Here is an example of a simple Scala.js project using the Vite template:
 You can use this to get started with your own project quickly, and simply start using the Sounds of Scala library from within the **firstMusicProgram** method.
 
 ```scala 3
+import cats.effect.{IO, Ref}
+import cats.effect.unsafe.implicits.global
 import org.scalajs.dom
 import org.scalajs.dom.{AudioContext, document}
+import org.soundsofscala.models.*
+import org.soundsofscala.transport.Sequencer
 
 @main
 def helloWorld(): Unit =
 
-  // create a page wrapper
   val homeDiv = document.createElement("div")
 
-  // create page title
   val heading = document.createElement("h1")
   heading.textContent = "My First Music App"
 
-  // create a play button for testing
   val button = document.createElement("button").asInstanceOf[dom.html.Button]
   button.classList.add("button")
   button.textContent = "▶️"
   button.onclick = _ =>
-    
-    // We always need an AudioContext to play web audio - more info on this coming up
     given AudioContext = new AudioContext()
-    // call our first music program method
     firstMusicProgram().unsafeRunAndForget()
 
   homeDiv.appendChild(heading)

--- a/docs/src/pages/getting-started/playing-test-song.md
+++ b/docs/src/pages/getting-started/playing-test-song.md
@@ -4,38 +4,47 @@ Playing one of the example songs included with the library is a good way to chec
 
 To play one of these songs first import the following:
 
-```scala
-import org.soundsofscala.models.Song
-import org.soundsofscala.songs.*
+```scala 3
+import cats.effect.{IO, Ref}
+import org.scalajs.dom.AudioContext
+import org.soundsofscala.models.*
+import org.soundsofscala.songexamples.*
+import org.soundsofscala.transport.Sequencer
 ```
 
-Before we can produce any sounds from our browser, the first components we need in any Web Audio project in an AudioContext.
+Before we can produce any sounds from our browser, the first component we need in any Web Audio project is an AudioContext.
 
 The AudioContext is the fundamental component in the Web Audio API for controlling the execution of Audio.
 
 [Read about the AudioContext](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext "AudioContext")
 
-All audio components in the Sounds of Scala library need an implicit/given AudioContext. We can define a given AudiContext as follows:
+All audio components in the Sounds of Scala library need an implicit/given AudioContext. We can define a given AudioContext as follows:
 
-```scala
-given AudioContext = new dom.AudioContext()
+```scala 3
+given AudioContext = new AudioContext()
 ```
 
-Now using the **firstMusicProgram** method from the example project on the previous page a simple song can be defined as follows:
+Now using the **firstMusicProgram** method from the example project on the previous page a simple song can be played as follows:
 
 ```scala 3
 def firstMusicProgram(): AudioContext ?=> IO[Unit] =
-  // TODO: Your code
-  ExampleSong1().play()
-
+  for
+    song      <- ExampleSong1.song()
+    songRef   <- Ref.of[IO, Song](song)
+    sequencer <- Sequencer(songRef)
+    _         <- sequencer.play()
+  yield ()
 ```
 
-Once you have played that and heard some Audio playing you can:
+The `Song` is pure data — it holds the title, tempo, swing and mixer (tracks). To play it, we wrap it in a `Ref[IO, Song]` and pass it to a `Sequencer`. The Ref enables real-time updates to any property while the song is playing.
+
+Once you have played that and heard some audio playing you can:
 - Click into `ExampleSong1` and see how the song is defined
 - Try changing the song to play one of the other example songs:
-    - `ExampleSong2ChromaticScale`
-    - `ExampleSong3Chords`
-    - `ExampleSong4Beethoven`
-    - `ExampleDrumBeat1`
+    - `ExampleSong2`
+    - `ExampleSong3`
+    - `ExampleSong4`
+    - `ExampleSong5Beethoven`
+    - `ExampleSong6`
 
 ### [Next Step: Creating your own Song](../music-dsl/songs.md#the-song-type)

--- a/docs/src/pages/music-dsl/building-beats.md
+++ b/docs/src/pages/music-dsl/building-beats.md
@@ -52,12 +52,15 @@ If we want to indicate bars, we can use the **`|`** operator:
   | RestQuarter + SnareDrum + RestQuarter + SnareDrum
 ```
 
-### The 'loop' operator
-We can also loop a section of music using the **`loop`** method:
+### The 'repeat' method
+We can also repeat a section of music a specific number of times using the **`repeat`** method:
 
 ```scala 3
-(RestQuarter + SnareDrum).loop(4)
+(RestQuarter + SnareDrum).repeat(4)
 ```
+
+For continuous looping during playback, set `Playback.Loop` on the Track instead — see [The Song Type](../music-dsl/songs.md#the-track-type).
+
 ### [Next Step: Building Notes](../music-dsl/building-notes.md)
 
 

--- a/docs/src/pages/music-dsl/quick-song.md
+++ b/docs/src/pages/music-dsl/quick-song.md
@@ -5,31 +5,38 @@ Lets just dive in here with a Song example before explaining the components invo
 
 ```scala 3
 def firstMusicProgram(): AudioContext ?=> IO[Unit] =
-  // TODO: Your code
-  writingAFirstSong().play()  // play the below song
+  for
+    song      <- writingAFirstSong()
+    songRef   <- Ref.of[IO, Song](song)
+    sequencer <- Sequencer(songRef)
+    _         <- sequencer.play()
+  yield ()
 
-def writingAFirstSong(): AudioContext ?=> Song =
+def writingAFirstSong(): AudioContext ?=> IO[Song] =
 
   // define musical events - here we define a softly played C major chord repeated 4 times
   val cMajorFourTimes: MusicalEvent = Cmaj.soft * 4
 
-  // pass the musical events into a track, alongside a track title and an instrument to play the musical events with
-  val track1 = Track(
-    title = Title("Scala Synth Bassline"),
-    musicalEvent = cMajorFourTimes,
-    instrument = ScalaSynth())
-
-  val track2 = Track(
-    title = Title("Pulsing Kick Drum"),
-    musicalEvent = KickDrum.eighth.loud * 8,
-    instrument = SimpleDrumMachine())
-
-  // pass the tracks to the mixer
-  val mixer = Mixer(track1, track2)
-
-  // pass the mixer alongside title, tempo and swing into the song
-  Song(Title("First, Maybe Last Song"), Tempo(120), Swing(0), mixer)
-)
+  for
+    scalaSynth  <- ScalaSynth()
+    drumMachine <- Simple80sDrumMachine()
+  yield Song(
+    title = Title("First, Maybe Last Song"),
+    tempo = Tempo(120),
+    swing = Swing(0),
+    mixer = Mixer(
+      Track(
+        title = Title("Scala Synth Bassline"),
+        musicalEvent = cMajorFourTimes,
+        instrument = scalaSynth,
+        playback = Playback.OneShot),
+      Track(
+        title = Title("Pulsing Kick Drum"),
+        musicalEvent = KickDrum.eighth.loud * 8,
+        instrument = drumMachine,
+        playback = Playback.Loop)
+    )
+  )
 ```
 
 ### [Next Step: The Song type](../music-dsl/songs.md)

--- a/docs/src/pages/music-dsl/songs.md
+++ b/docs/src/pages/music-dsl/songs.md
@@ -1,6 +1,6 @@
 ## The Song Type
 
-The Song type is the top level object containing all elements required to play a song.
+The Song type is the top level data structure containing all elements required to define a song. Song is pure data — it holds no mutable state and has no side effects.
 
 ```scala 3
 case class Song(
@@ -16,11 +16,11 @@ The title, tempo and swing, should be self explanatory and take provided types w
 
 ### The Mixer Type
 
-Mixer is where we we will place all our **Tracks** and this will simulate the effect of a real world mixing desk, where we can simultaneously play and manipulate audio on multiple tracks.
+Mixer is where we will place all our **Tracks** and this will simulate the effect of a real world mixing desk, where we can simultaneously play and manipulate audio on multiple tracks.
 
 
 ```scala 3
-case class Mixer(tracks: NonEmptyList[Track])
+case class Mixer(tracks: NonEmptyList[Track[?]])
 ```
 
 > NOTE: The **NonEmptyList** type is a type from the [cats library](https://typelevel.org/cats/datatypes/nel.html) which ensures that the list is never empty.
@@ -32,16 +32,37 @@ case class Mixer(tracks: NonEmptyList[Track])
 Tracks in turn, are where we will place:
 - The musical events we want to play.
 - The instruments we want to play those events with.
-- Any insert FX we want to apply to the track. [Insert FX](https://en.wikipedia.org/wiki/Insert_(effects_processing))
-- Any send FX we want to apply to the track. [Send FX](https://en.wikipedia.org/wiki/Aux-send)
+- The playback mode — `Playback.Loop` for continuously looping tracks (e.g. drums) or `Playback.OneShot` for tracks that play once and stop (e.g. arranged parts).
+- TODO: Any insert FX we want to apply to the track. [Insert FX](https://en.wikipedia.org/wiki/Insert_(effects_processing))
+- TODO: Any send FX we want to apply to the track. [Send FX](https://en.wikipedia.org/wiki/Aux-send)
 
 ```scala 3
-case class Track(
-                  title: Title,
-                  musicalEvent: MusicalEvent,
-                  instrument: Instrument,
-                  insertFX: List[FX] = List.empty,
-                  sendFX: List[FX] = List.empty)
+case class Track[Settings](
+    title: Title,
+    musicalEvent: MusicalEvent,
+    instrument: Instrument[Settings],
+    playback: Playback,
+    customSettings: Option[Settings] = None,
+    insertFX: List[FX] = List.empty,
+    sendFX: List[FX] = List.empty)
+```
+
+### Playing a Song with the Sequencer
+
+Song is pure data — to play it, wrap it in a `Ref[IO, Song]` and pass it to a `Sequencer`:
+
+```scala 3
+for
+  songRef   <- Ref.of[IO, Song](mySong)
+  sequencer <- Sequencer(songRef)
+  _         <- sequencer.play()
+yield ()
+```
+
+The `Ref` enables real-time updates to any song property while it's playing:
+
+```scala 3
+sequencer.updateSong(_.copy(tempo = Tempo(140)))
 ```
 
 ### [Next Step: Musical Events](../music-dsl/musical-events.md)

--- a/js/src/main/scala/org/soundsofscala/Main.scala
+++ b/js/src/main/scala/org/soundsofscala/Main.scala
@@ -15,8 +15,11 @@
  */
 package org.soundsofscala
 
+import cats.data.NonEmptyList
+import cats.effect.Ref
 import cats.effect.unsafe.implicits.global
 import cats.effect.{ExitCode, IO, IOApp}
+import cats.syntax.all.*
 import org.scalajs.dom
 import org.scalajs.dom.*
 import org.soundsofscala.graph.AudioGraphDemoCode
@@ -24,7 +27,7 @@ import org.soundsofscala.models.*
 import org.soundsofscala.playback.AudioPlayer
 import org.soundsofscala.songexamples.*
 import org.soundsofscala.syntax.all.*
-import cats.syntax.all.*
+import org.soundsofscala.transport.Sequencer
 
 object Main extends IOApp:
 
@@ -62,27 +65,41 @@ object Main extends IOApp:
       beethovenSong <- ExampleSong5Beethoven.song()
       pagodas <- ExampleSong6.song()
       exampleSong1 <- ExampleSong1.song()
-      kickRef = exampleSong1.mixer.tracks.head.musicalEventRef
+
+      song1Ref <- Ref.of[IO, Song](exampleSong1)
+      song1Sequencer <- Sequencer(song1Ref)
+
+      beethovenRef <- Ref.of[IO, Song](beethovenSong)
+      beethovenSequencer <- Sequencer(beethovenRef)
+
+      pagodasRef <- Ref.of[IO, Song](pagodas)
+      pagodasSequencer <- Sequencer(pagodasRef)
+
       altKickPattern: MusicalEvent = C2.eighth + C2.eighth + RestQuarter.onFull
       exampleSong1ButtonGroup <- buildButtonGroup(
         label = "ExampleSong1",
-        playAction = exampleSong1.play(),
-        stopAction = exampleSong1.stop(),
-        updateAction = kickRef.get.flatMap: current =>
-          if current == ExampleSong1.kickDrum
-          then kickRef.set(altKickPattern) >> IO.println("Kick pattern: double kick")
-          else kickRef.set(ExampleSong1.kickDrum) >> IO.println("Kick pattern: original")
-        .some
+        playAction = song1Sequencer.play(),
+        stopAction = song1Sequencer.stop(),
+        updateAction = song1Ref.modify { song =>
+          val kick = song.mixer.tracks.head
+          val (newEvent, label) =
+            if kick.musicalEvent == ExampleSong1.kickDrum
+            then (altKickPattern, "double kick")
+            else (ExampleSong1.kickDrum, "original")
+          val updatedSong = song.copy(
+            mixer = Mixer(NonEmptyList(kick.withMusicalEvent(newEvent), song.mixer.tracks.tail)))
+          (updatedSong, label)
+        }.flatMap(label => IO.println(s"Kick pattern: $label")).some
       )
       beethovenButtonGroup <- buildButtonGroup(
         label = "ExampleSong4Beethoven",
-        playAction = beethovenSong.play(),
-        stopAction = beethovenSong.stop()
+        playAction = beethovenSequencer.play(),
+        stopAction = beethovenSequencer.stop()
       )
       exampleSong5PagodasGroup <- buildButtonGroup(
         label = "ExampleSong5Pagodas",
-        playAction = pagodas.play(),
-        stopAction = pagodas.stop()
+        playAction = pagodasSequencer.play(),
+        stopAction = pagodasSequencer.stop()
       )
       audioGraphButton <- buildButton(
         label = "Audio Graph in action ▶",
@@ -136,7 +153,7 @@ object Main extends IOApp:
 
     val codeStringSbt: String =
       """|
-         |"libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.4.1""".stripMargin
+         |"libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0""".stripMargin
 
     val addToCode = document.createElement("p")
     addToCode.textContent =
@@ -304,20 +321,18 @@ object Main extends IOApp:
 
       updateButton <- updateAction.fold(IO.pure(None))(action =>
         for
-          btn <- IO(document.createElement("button"))
+          button <- IO(document.createElement("button"))
           _ <- IO {
-            btn.textContent = "update - realtime"
-            btn.classList.add("update-button")
-            btn.addEventListener("click", (_: dom.MouseEvent) => action.unsafeRunAndForget())
+            button.textContent = "update - realtime"
+            button.classList.add("update-button")
+            button.addEventListener("click", (_: dom.MouseEvent) => action.unsafeRunAndForget())
           }
-        yield Some(btn))
-      _ <- IO {
-        buttonContainer.appendChild(playButton)
-        buttonContainer.appendChild(stopButton)
-        groupContainer.appendChild(labelElement)
-        groupContainer.appendChild(buttonContainer)
-        updateButton.foreach(buttonContainer.appendChild(_))
-      }
+        yield button.some)
+      _ <- IO(buttonContainer.appendChild(playButton))
+      _ <- IO(buttonContainer.appendChild(stopButton))
+      _ <- IO(groupContainer.appendChild(labelElement))
+      _ <- IO(groupContainer.appendChild(buttonContainer))
+      _ <- IO(updateButton.foreach(buttonContainer.appendChild(_)))
     yield groupContainer
 
 end Main

--- a/js/src/main/scala/org/soundsofscala/models/Song.scala
+++ b/js/src/main/scala/org/soundsofscala/models/Song.scala
@@ -17,41 +17,13 @@
 package org.soundsofscala.models
 
 import cats.data.NonEmptyList
-import cats.effect.IO
-import cats.effect.kernel.Fiber
-import org.scalajs.dom.AudioContext
-import org.soundsofscala.transport.Sequencer
 
 case class Song(
     title: Title,
     tempo: Tempo = Tempo(120),
     swing: Swing = Swing(0),
     mixer: Mixer
-):
-  // scalafix:off DisableSyntax.var
-  private var runningSequencer: Option[Fiber[IO, Throwable, Unit]] = None
-
-  def play()(using AudioContext): IO[Unit] =
-    for
-      _ <- IO.println(s"Playing: $title")
-      _ <- stop() // Stop any currently running sequencer first
-      fiber <- Sequencer().playSong(this).start
-      _ <- IO { runningSequencer = Some(fiber) }
-    yield ()
-
-  def stop(): IO[Unit] =
-    for
-      _ <- IO.println(s"Song.stop() called for: $title")
-      _ <- runningSequencer match
-        case Some(fiber) =>
-          IO.println("Cancelling running sequencer") *>
-            fiber.cancel *>
-            IO { runningSequencer = None }
-        case None =>
-          IO.println("No running sequencer to cancel")
-      _ <- Sequencer().stopSong(this) // Stop current oscillators
-    yield ()
-end Song
+)
 
 case class Mixer(tracks: NonEmptyList[Track[?]])
 object Mixer:

--- a/js/src/main/scala/org/soundsofscala/models/Track.scala
+++ b/js/src/main/scala/org/soundsofscala/models/Track.scala
@@ -17,7 +17,7 @@
 package org.soundsofscala.models
 
 import cats.effect.IO
-import cats.effect.Ref
+import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument.Default
 import org.soundsofscala.instrument.Instrument
 
@@ -26,7 +26,7 @@ enum Playback:
 
 case class Track[Settings](
     title: Title,
-    musicalEventRef: Ref[IO, MusicalEvent],
+    musicalEvent: MusicalEvent,
     instrument: Instrument[Settings],
     playback: Playback,
     customSettings: Option[Settings] = None,
@@ -34,21 +34,14 @@ case class Track[Settings](
     sendFX: List[FX] = List.empty)(using Default[Settings]):
   val settings: Settings = customSettings.getOrElse(Default.default[Settings])
 
-object Track:
-  def make[Settings](
-      title: Title,
-      musicalEvent: MusicalEvent,
-      instrument: Instrument[Settings],
-      playback: Playback,
-      customSettings: Option[Settings] = None,
-      insertFX: List[FX] = List.empty,
-      sendFX: List[FX] = List.empty)(using Default[Settings]): IO[Track[Settings]] =
-    Ref.of[IO, MusicalEvent](musicalEvent).map: updateableMusicalEventRef =>
-      new Track(
-        title,
-        updateableMusicalEventRef,
-        instrument,
-        playback,
-        customSettings,
-        insertFX,
-        sendFX)
+  def withMusicalEvent(newEvent: MusicalEvent): Track[Settings] =
+    Track(title, newEvent, instrument, playback, customSettings, insertFX, sendFX)
+
+  def playAtomicMusicalEvent(
+      event: AtomicMusicalEvent,
+      when: Double,
+      tempo: Tempo)(using AudioContext): IO[Unit] =
+    event match
+      case AtomicMusicalEvent.Rest(_) => IO.unit
+      case e: AtomicMusicalEvent =>
+        instrument.play(e, when, tempo)(settings)

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong1.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong1.scala
@@ -21,6 +21,7 @@ import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument.*
 import org.soundsofscala.models.*
+import org.soundsofscala.models.Playback
 import org.soundsofscala.syntax.all.*
 
 object ExampleSong1:
@@ -72,9 +73,9 @@ object ExampleSong1:
     RestQuarter.quarterDotted + A4.eighth + D5.eighth + E5.quarter + F5.quarterDotted +
       E5.eighth + RestEighth + D5.eighth + C5.eighth + D5.quarter + D5.quarter + RestQuarter + RestHalf + OneBarRest
 
-  val kickDrum: MusicalEvent = C2 + RestQuarter.onFull
-  val snareDrum: MusicalEvent = RestQuarter + D2
-  val hiHats: MusicalEvent = E2.eighth.medium * 4
+  val kickDrum: MusicalEvent = (C2 + RestQuarter.onFull).repeat(32)
+  val snareDrum: MusicalEvent = (RestQuarter + D2).repeat(32)
+  val hiHats: MusicalEvent = (E2.eighth.medium * 4).repeat(32)
 
   private def drumSampler(): AudioContext ?=> IO[Sampler] = Sampler.fromPaths(
     List(
@@ -94,60 +95,51 @@ object ExampleSong1:
       quirkySynth <- QuirkyFilterSynth()
       scalaSynth <- ScalaSynth()
       guitar <- Sampler.guitar
-      kickTrack <-
-        Track.make(
+    yield Song(
+      title = Title("Song Example 1"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(
           Title("Kick"),
           kickDrum,
           drums,
-          Playback.Loop,
-          customSettings = Some(drumSamplerSettings))
-      snareTrack <- Track.make(
-        Title("Snare"),
-        snareDrum,
-        drums,
-        Playback.Loop,
-        customSettings = Some(drumSamplerSettings))
-      hatsTrack <- Track.make(
-        Title("Hats"),
-        hiHats,
-        drums,
-        Playback.Loop,
-        customSettings = Some(drumSamplerSettings))
-      bassTrack <- Track.make(
-        Title("Live Bass Guitar"),
-        TwoBarRest + bassline.repeat(12),
-        bassGuitar,
-        Playback.OneShot)
-      synthBassTrack <- Track.make(
-        Title("Scala Synth Bass Line"),
-        FourBarRest + scalaSynthLine.repeat(12),
-        scalaSynth,
-        Playback.OneShot)
-      guitarTrack <- Track.make(
-        Title("Live Guitar"),
-        FourBarRest + (TwoBarRest + guitarPart).repeat(4),
-        guitar,
-        Playback.OneShot,
-        customSettings = guitarSamplerSettings.some)
-      leadTrack <- Track.make(
-        Title("Lead Line"),
-        FourBarRest + verseMelody.repeat(4),
-        quirkySynth,
-        Playback.OneShot,
-        customSettings = quirkySynthSettings.some)
-      song = Song(
-        title = Title("Song Example 1"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(
-          kickTrack,
-          snareTrack,
-          hatsTrack,
-          bassTrack,
-          synthBassTrack,
-          guitarTrack,
-          leadTrack
-        )
+          Playback.OneShot,
+          customSettings = drumSamplerSettings.some),
+        Track(
+          Title("Snare"),
+          snareDrum,
+          drums,
+          Playback.OneShot,
+          customSettings = drumSamplerSettings.some),
+        Track(
+          Title("Hats"),
+          hiHats,
+          drums,
+          Playback.OneShot,
+          customSettings = drumSamplerSettings.some),
+        Track(
+          Title("Live Bass Guitar"),
+          TwoBarRest + bassline.repeat(12),
+          bassGuitar,
+          Playback.OneShot),
+        Track(
+          Title("Scala Synth Bass Line"),
+          FourBarRest + scalaSynthLine.repeat(12),
+          scalaSynth,
+          Playback.OneShot),
+        Track(
+          Title("Live Guitar"),
+          FourBarRest + (TwoBarRest + guitarPart).repeat(2),
+          guitar,
+          Playback.OneShot,
+          customSettings = guitarSamplerSettings.some),
+        Track(
+          Title("Lead Line"),
+          FourBarRest + verseMelody.repeat(4),
+          quirkySynth,
+          Playback.OneShot,
+          customSettings = quirkySynthSettings.some)
       )
-    yield song
+    )
 end ExampleSong1

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong2.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong2.scala
@@ -17,6 +17,7 @@
 package org.soundsofscala.songexamples
 
 import cats.effect.IO
+import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument.{SamplePlayer, Sampler}
 import org.soundsofscala.models.*
@@ -38,21 +39,19 @@ object ExampleSong2:
       length = Some(2)
     )
 
-  def play(): AudioContext ?=> IO[Unit] =
+  def song(): AudioContext ?=> IO[Song] =
     for
       piano <- Sampler.piano
-      track <- Track.make(
-        Title("rhubarb D3"),
-        musicalEvent,
-        piano,
-        Playback.Loop,
-        customSettings = Some(customSettings))
-      song = Song(
-        title = Title("Rhubarb Loop"),
-        tempo = Tempo(60),
-        swing = Swing(0),
-        mixer = Mixer(track)
-      )
-      a <- song.play()
-    yield a
+    yield Song(
+      title = Title("Rhubarb Loop"),
+      tempo = Tempo(60),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(
+          Title("rhubarb D3"),
+          musicalEvent,
+          piano,
+          Playback.Loop,
+          customSettings = customSettings.some))
+    )
 end ExampleSong2

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong3.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong3.scala
@@ -41,16 +41,14 @@ object ExampleSong3:
   val musicalEvent: MusicalEvent =
     Dmin7 + Amin7 + Dmin7 + Amin7 + Dmin7 + Amin7 + Dmin7 + Amin7
 
-  def play(): AudioContext ?=> IO[Unit] =
+  def song(): AudioContext ?=> IO[Song] =
     for
-      piano <- Sampler.guitar
-      track <- Track.make(Title("Single Synth Voice"), musicalEvent, piano, Playback.OneShot)
-      song = Song(
-        title = Title("Dissonant Twinkle Twinkle"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(track)
-      )
-      _ <- song.play()
-    yield ()
+      guitar <- Sampler.guitar
+    yield Song(
+      title = Title("Dissonant Twinkle Twinkle"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(Title("Single Synth Voice"), musicalEvent, guitar, Playback.OneShot))
+    )
 end ExampleSong3

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong4.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong4.scala
@@ -38,18 +38,17 @@ object ExampleSong4:
       simple80sDrumMachine <- Simple80sDrumMachine()
       liveBass <- Sampler.bassGuitar
       scalaSynth <- QuirkyFilterSynth()
-      bassTrack <- Track.make(Title("Live Bass"), musicalEvent, liveBass, Playback.OneShot)
-      synthTrack <-
-        Track.make(Title("Scala Synth Line"), scalaSynthLine, scalaSynth, Playback.OneShot)
-      kickTrack <- Track.make(Title("Kick"), kd, simple80sDrumMachine, Playback.OneShot)
-      snareTrack <- Track.make(Title("Snare"), sd, simple80sDrumMachine, Playback.OneShot)
-      hatsTrack <- Track.make(Title("Hats"), ht, simple80sDrumMachine, Playback.OneShot)
-      song = Song(
-        title = Title("long note"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(bassTrack, synthTrack, kickTrack, snareTrack, hatsTrack)
+    yield Song(
+      title = Title("long note"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(Title("Live Bass"), musicalEvent, liveBass, Playback.OneShot),
+        Track(Title("Scala Synth Line"), scalaSynthLine, scalaSynth, Playback.OneShot),
+        Track(Title("Kick"), kd, simple80sDrumMachine, Playback.OneShot),
+        Track(Title("Snare"), sd, simple80sDrumMachine, Playback.OneShot),
+        Track(Title("Hats"), ht, simple80sDrumMachine, Playback.OneShot)
       )
-    yield song
+    )
 
 end ExampleSong4

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong5Beethoven.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong5Beethoven.scala
@@ -17,6 +17,7 @@
 package org.soundsofscala.songexamples
 
 import cats.effect.IO
+import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument
 import org.soundsofscala.instrument.*
@@ -150,23 +151,23 @@ object ExampleSong5Beethoven:
   def song(): AudioContext ?=> IO[Song] =
     for
       sharedPiano <- PianoSynth()
-      upperTrack <- Track.make(
-        Title("Beethoven Upper Voice"),
-        upperVoice,
-        sharedPiano,
-        Playback.OneShot,
-        customSettings = Some(customSettings))
-      lowerTrack <- Track.make(
-        Title("Beethoven Lower Voice"),
-        lowerVoice,
-        sharedPiano,
-        Playback.OneShot,
-        customSettings = Some(customSettings))
-      song = Song(
-        title = Title("Something We All Know"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(upperTrack, lowerTrack)
+    yield Song(
+      title = Title("Something We All Know"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(
+          Title("Beethoven Upper Voice"),
+          upperVoice,
+          sharedPiano,
+          Playback.OneShot,
+          customSettings = customSettings.some),
+        Track(
+          Title("Beethoven Lower Voice"),
+          lowerVoice,
+          sharedPiano,
+          Playback.OneShot,
+          customSettings = customSettings.some)
       )
-    yield song
+    )
 end ExampleSong5Beethoven

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
@@ -1,13 +1,10 @@
 package org.soundsofscala.songexamples
 
-import org.soundsofscala.instrument.ViolinSynth
 import cats.effect.IO
 import org.scalajs.dom.AudioContext
-import org.soundsofscala.instrument
 import org.soundsofscala.instrument.*
 import org.soundsofscala.models.*
 import org.soundsofscala.syntax.all.*
-import org.soundsofscala.models.Playback
 
 object ExampleSong6:
 
@@ -28,17 +25,17 @@ object ExampleSong6:
   def song(): AudioContext ?=> IO[Song] =
     for
       violinSynth <- ViolinSynth()
-      trebleTrack <- Track.make(
-        Title("Laideronnette, impératrice des pagodes"),
-        measureOneTrebleClef + measureTwoTrebleClef + measureThreeTrebleClef + measureFourTrebleClef,
-        violinSynth,
-        Playback.OneShot
+    yield Song(
+      title = Title("Laideronnette, impératrice des pagodes"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(
+          Title("Laideronnette, impératrice des pagodes"),
+          measureOneTrebleClef + measureTwoTrebleClef + measureThreeTrebleClef + measureFourTrebleClef,
+          violinSynth,
+          Playback.OneShot
+        )
       )
-      song = Song(
-        title = Title("Laideronnette, impératrice des pagodes"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(trebleTrack)
-      )
-    yield song
+    )
 end ExampleSong6

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSongSampler.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSongSampler.scala
@@ -17,6 +17,7 @@
 package org.soundsofscala.songexamples
 
 import cats.effect.IO
+import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument.{SamplePlayer, Sampler}
 import org.soundsofscala.models.*
@@ -62,41 +63,31 @@ object ExampleSongSampler:
       length = Some(1)
     )
 
-  def play(): AudioContext ?=> IO[Unit] =
+  def song(): AudioContext ?=> IO[Song] =
     for
       rhubarb <- Sampler.rhubarb
       vinyl <- Sampler.vinyl
       sparkles <- Sampler.sparkles
       kick <- Sampler.kickDrum
       snare <- Sampler.snareDrum
-      rhubarbHighTrack <- Track.make(Title("RhubarbHigh"), rhubarbHigh, rhubarb, Playback.OneShot)
-      rhubarbLowTrack <- Track.make(Title("RhubarbLow"), rhubarbLow, rhubarb, Playback.OneShot)
-      vinylTrackT <- Track.make(Title("Vinyl"), vinylTrack, vinyl, Playback.OneShot)
-      sparklesTrackT <- Track.make(Title("Sparkles"), sparklesTrack, sparkles, Playback.OneShot)
-      sparklesRevTrack <- Track.make(
-        Title("SparklesReversed"),
-        sparklesTrackReversed,
-        sparkles,
-        Playback.OneShot,
-        customSettings = Some(customSettings))
-      kickTrackT <- Track.make(Title("Kick"), kickTrack, kick, Playback.OneShot)
-      snareTrackT <- Track.make(Title("Snare"), snareTrack, snare, Playback.OneShot)
-      vinylHihatTrack <- Track.make(Title("VinylHihat"), vinylHihat, vinyl, Playback.OneShot)
-      song = Song(
-        title = Title("Rhubarb"),
-        tempo = Tempo(110),
-        swing = Swing(0),
-        mixer = Mixer(
-          rhubarbHighTrack,
-          rhubarbLowTrack,
-          vinylTrackT,
-          sparklesTrackT,
-          sparklesRevTrack,
-          kickTrackT,
-          snareTrackT,
-          vinylHihatTrack
-        )
+    yield Song(
+      title = Title("Rhubarb"),
+      tempo = Tempo(110),
+      swing = Swing(0),
+      mixer = Mixer(
+        Track(Title("RhubarbHigh"), rhubarbHigh, rhubarb, Playback.OneShot),
+        Track(Title("RhubarbLow"), rhubarbLow, rhubarb, Playback.OneShot),
+        Track(Title("Vinyl"), vinylTrack, vinyl, Playback.OneShot),
+        Track(Title("Sparkles"), sparklesTrack, sparkles, Playback.OneShot),
+        Track(
+          Title("SparklesReversed"),
+          sparklesTrackReversed,
+          sparkles,
+          Playback.OneShot,
+          customSettings = customSettings.some),
+        Track(Title("Kick"), kickTrack, kick, Playback.OneShot),
+        Track(Title("Snare"), snareTrack, snare, Playback.OneShot),
+        Track(Title("VinylHihat"), vinylHihat, vinyl, Playback.OneShot)
       )
-      a <- song.play()
-    yield a
+    )
 end ExampleSongSampler

--- a/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
@@ -19,82 +19,66 @@ package org.soundsofscala.transport
 import cats.effect.IO
 import cats.effect.Ref
 import org.scalajs.dom.AudioContext
-import org.soundsofscala.instrument.Instrument
-import org.soundsofscala.models
-import org.soundsofscala.models.AtomicMusicalEvent.*
 import org.soundsofscala.models.*
-import org.soundsofscala.models.Playback
 
 import scala.concurrent.duration.DurationDouble
 
 /**
- * The `NoteScheduler` is responsible for scheduling the notes of a single track. It uses the
- * `ScheduleStatus` to determine if the next note should be scheduled. We can start them at a
- * precise time with the currentTime property of the AudioContext. The method of scheduling notes in
- * the browser is derived from the following: https://web.dev/articles/audio-scheduling
- * https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques#playing_the_audio_in_time
+ * The `NoteScheduler` is responsible for scheduling the notes of a single track. It reads the
+ * current Song from a `Ref[IO, Song]`, extracting the track by index. Tempo is re-read per-note for
+ * live tempo changes. The track's pattern, instrument, and playback mode are re-read at each cycle
+ * boundary.
  *
- * The scheduler reads the current MusicalEvent from a Ref at the start of each cycle, allowing live
- * updates to take effect at sequence boundaries.
- *
- * @param tempo
- *   The tempo of the song. This is needed to determine the how many seconds a note is played for
+ * @param songRef
+ *   A Ref holding the current Song, re-read for live updates
  * @param lookAheadMs
  *   The time in milliseconds to look ahead to determine if the next note should be scheduled
  * @param scheduleAheadTimeSeconds
  *   The time window in seconds in which to schedule notes ahead of time
  */
 final case class NoteScheduler(
-    tempo: Tempo,
+    songRef: Ref[IO, Song],
     lookAheadMs: LookAhead,
     scheduleAheadTimeSeconds: ScheduleWindow):
 
-  def scheduleInstrument[Settings](
-      eventRef: Ref[IO, MusicalEvent],
-      instrument: Instrument[Settings],
-      settings: Settings,
-      looping: Playback)(
-      using audioContext: AudioContext): IO[Unit] =
-
+  def scheduleTrack(trackIndex: Int)(using ac: AudioContext): IO[Unit] =
     def loop(nextNoteTime: NextNoteTime): IO[Unit] =
       for
-        currentEvent <- eventRef.get
-        finalNoteTime <- scheduleSequence(currentEvent, nextNoteTime, instrument, settings)
-        _ <- if looping == Playback.Loop then loop(finalNoteTime) else IO.unit
+        song <- songRef.get
+        track = song.mixer.tracks.toList(trackIndex)
+        finalNoteTime <- scheduleSequence(
+          track,
+          track.musicalEvent,
+          nextNoteTime)
+        _ <-
+          if track.playback == Playback.Loop
+          then loop(finalNoteTime)
+          else IO.unit
       yield ()
 
-    loop(NextNoteTime(audioContext.currentTime))
+    loop(NextNoteTime(ac.currentTime))
 
-  private def scheduleSequence[Settings](
+  private def scheduleSequence(
+      track: Track[?],
       musicalEvent: MusicalEvent,
-      nextNoteTime: NextNoteTime,
-      instrument: Instrument[Settings],
-      settings: Settings): AudioContext ?=> IO[NextNoteTime] =
+      nextNoteTime: NextNoteTime)(using AudioContext): IO[NextNoteTime] =
     ScheduleStatus(nextNoteTime, scheduleAheadTimeSeconds) match
       case ScheduleStatus.Ready =>
-        musicalEvent match
-          case sequence: Sequence =>
-            val nextNextNoteTime =
-              NextNoteTime(nextNoteTime.value + sequence.head.durationToSeconds(tempo))
-            scheduleAtomicEvent(sequence.head, nextNoteTime, instrument, settings) >>
-              scheduleSequence(sequence.tail, nextNextNoteTime, instrument, settings)
-          case atomicEvent: AtomicMusicalEvent =>
-            val nextNextNoteTime =
-              NextNoteTime(nextNoteTime.value + atomicEvent.durationToSeconds(tempo))
-            scheduleAtomicEvent(atomicEvent, nextNoteTime, instrument, settings)
-              .as(nextNextNoteTime)
+        songRef.get.flatMap: song =>
+          val tempo = song.tempo
+          musicalEvent match
+            case sequence: Sequence =>
+              val nextNextNoteTime =
+                NextNoteTime(nextNoteTime.value + sequence.head.durationToSeconds(tempo))
+              track.playAtomicMusicalEvent(sequence.head, nextNoteTime.value, tempo) >>
+                scheduleSequence(track, sequence.tail, nextNextNoteTime)
+            case atomicEvent: AtomicMusicalEvent =>
+              val nextNextNoteTime =
+                NextNoteTime(nextNoteTime.value + atomicEvent.durationToSeconds(tempo))
+              track.playAtomicMusicalEvent(atomicEvent, nextNoteTime.value, tempo)
+                .as(nextNextNoteTime)
 
       case ScheduleStatus.Waiting =>
         IO.sleep(lookAheadMs.value.millis) >>
-          scheduleSequence(musicalEvent, nextNoteTime, instrument, settings)
-
-  private def scheduleAtomicEvent[Settings](
-      musicalEvent: AtomicMusicalEvent,
-      nextNoteTime: NextNoteTime,
-      instrument: Instrument[Settings],
-      settings: Settings): AudioContext ?=> IO[Unit] =
-    musicalEvent match
-      case Rest(_) => IO.unit
-      case event: AtomicMusicalEvent =>
-        instrument.play(event, nextNoteTime.value, tempo)(settings)
+          scheduleSequence(track, musicalEvent, nextNoteTime)
 end NoteScheduler

--- a/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
@@ -17,38 +17,69 @@
 package org.soundsofscala.transport
 
 import cats.effect.IO
+import cats.effect.Ref
+import cats.effect.kernel.Fiber
 import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.models.LookAhead
-import org.soundsofscala.models.Playback
 import org.soundsofscala.models.ScheduleWindow
 import org.soundsofscala.models.Song
 
 /**
  * The sequencer is responsible for scheduling the notes of every track in the song in parallel. It
- * uses a `NoteScheduler` which responsible for scheduling the notes of a single track.
- * @param song
- *   The song to be played.
+ * holds a `Ref[IO, Song]` so that all song properties (tempo, swing, track patterns, instruments,
+ * etc.) can be updated in real time via the same Ref.
+ *
+ * To change the song being played, update the Song inside the Ref — don't create a new Sequencer.
+ *
+ * @param songRef
+ *   A Ref holding the current Song, enabling live updates to any property
  */
 
-case class Sequencer():
+class Sequencer private (
+    val songRef: Ref[IO, Song],
+    private val fiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]]
+)(using audioContext: AudioContext):
 
-  def stopSong(song: Song): IO[Unit] =
-    IO.println(s"Sequencer.stopSong() called for: ${song.title}") *>
-      song.mixer.tracks.parTraverse: track =>
-        track.instrument.stop.void
-      .void
+  def updateSong(f: Song => Song): IO[Unit] = songRef.update(f)
 
-  def playSong(song: Song)(using audioContext: AudioContext): IO[Unit] =
-    val noteScheduler = NoteScheduler(song.tempo, LookAhead(25), ScheduleWindow(0.1))
-    song
-      .mixer
-      .tracks
-      .parTraverse: track =>
-        noteScheduler
-          .scheduleInstrument(
-            track.musicalEventRef,
-            track.instrument,
-            track.settings,
-            track.playback)
-      .void
+  def play(): IO[Unit] =
+    for
+      song <- songRef.get
+      _ <- IO.println(s"Playing: ${song.title}")
+      _ <- stop()
+      fiber <- startPlayback().start
+      _ <- fiberRef.set(fiber.some)
+    yield ()
+
+  def stop(): IO[Unit] =
+    fiberRef.getAndSet(none).flatMap:
+      case Some(fiber) =>
+        IO.println("Cancelling running sequencer") *>
+          fiber.cancel *>
+          stopInstruments()
+      case none => IO.unit
+
+  private def stopInstruments(): IO[Unit] =
+    songRef.get.flatMap(_.mixer.tracks.parTraverse(_.instrument.stop.void).void)
+
+  private def startPlayback(): IO[Unit] =
+    songRef.get.flatMap: song =>
+      val noteScheduler = NoteScheduler(songRef, LookAhead(25), ScheduleWindow(0.1))
+      song
+        .mixer
+        .tracks
+        .toList
+        .zipWithIndex
+        .parTraverse: (_, index) =>
+          noteScheduler.scheduleTrack(index)
+        .void *>
+        songRef.get.flatMap(s => IO.println(s"Finished playing: ${s.title}"))
+end Sequencer
+
+object Sequencer:
+  def apply(songRef: Ref[IO, Song])(using AudioContext): IO[Sequencer] =
+    Ref.of[IO, Option[Fiber[IO, Throwable, Unit]]](none).map: fiberRef =>
+      new Sequencer(songRef, fiberRef)
+
+end Sequencer

--- a/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
@@ -20,6 +20,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.models.LookAhead
+import org.soundsofscala.models.Playback
 import org.soundsofscala.models.ScheduleWindow
 import org.soundsofscala.models.Song
 

--- a/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
@@ -62,8 +62,6 @@ sealed trait MusicalEvent:
 
   def repeat: MusicalEvent = repeat(2)
 
-  def loop: MusicalEvent = repeat(128) // Lets see if this 💥
-
   @targetName("repeatMusicEvents")
   def *(repetitions: Int): MusicalEvent = repeat(repetitions)
 


### PR DESCRIPTION
## PR: Make Song a Ref to enable all real-time updates

### Summary

Architectural refactor that separates Song (pure data) from Sequencer (playback behaviour), enabling real-time updates to **any** song property — tempo, swing, track patterns, instruments, effects — through a single `Ref[IO, Song]`.

- **Song is now pure data**: Removed `play()`, `stop()`, mutable fiber management, and all `Ref` fields from `Song`. It's now a plain `case class Song(title, tempo, swing, mixer)` with no IO, no side effects, no imports from cats-effect.
- **Track is now pure data**: Removed `Ref[IO, MusicalEvent]` and the effectful `Track.make` smart constructor. Tracks are constructed as plain values again. Added `withMusicalEvent` for convenient immutable updates and `playAtomicMusicalEvent` to handle existential type alignment internally.
- **Sequencer owns all playback behaviour**: Takes a `Ref[IO, Song]` and manages fiber lifecycle. Uses `Ref[IO, Option[Fiber[...]]]` instead of a mutable `var` for the running fiber, making stop/start atomic. Provides `updateSong(f: Song => Song)` for live mutation. Prints when a song finishes playing.
- **NoteScheduler reads from the Song Ref**: Instead of taking individual `Ref`s for tempo and events, it takes the `songRef` and a track index. Tempo is re-read per-note (live tempo changes). Track pattern and playback mode are re-read per-cycle (live pattern swaps at sequence boundaries).
- **Removed `MusicalEvent.loop`**: The old `repeat(128)` pre-computation is replaced by `Playback.Loop` on the Track, with the Sequencer looping infinitely and re-reading the Ref each cycle.
- **Simplified all song examples**: Track and Song construction is no longer effectful — only instrument creation remains in `IO`. `Track.make(...)` with `<-` becomes `Track(...)` with `=`. `Some(settings)` replaced with `settings.some` throughout.

### Breaking changes

- `Song` no longer has `play()` or `stop()` methods — create a `Sequencer` instead
- `Track.make` removed — use `Track(...)` directly (non-effectful)
- `Track.musicalEventRef` removed — `Track.musicalEvent` is a plain `MusicalEvent` again
- `Song` constructor no longer returns `IO[Song]` — it's a plain case class
- `MusicalEvent.loop` removed — use `Playback.Loop` on the Track
- `Sequencer` constructor is now effectful: `Sequencer(songRef): IO[Sequencer]`
- Version bumped to 0.7

### Migration guide

Before:

```
for
  track <- Track.make(Title("Kick"), kickDrum, drums, Playback.Loop)
  song  <- Song(title = Title("My Song"), tempo = Tempo(120), mixer = Mixer(track))
  _     <- song.play()
  _     <- song.stop()
yield ()
```

After:

```
for
  songRef    <- Ref.of[IO, Song](Song(
                  title = Title("My Song"), tempo = Tempo(120),
                  mixer = Mixer(Track(Title("Kick"), kickDrum, drums, Playback.Loop))))
  sequencer  <- Sequencer(songRef)
  _          <- sequencer.play()
  _          <- songRef.update(_.copy(tempo = Tempo(140)))  // live tempo change!
  _          <- sequencer.stop()
yield ()
```
