### PR TITLE
SOS-060 Adding swing feature - correcting realtime song updates - bump deps

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -58,3 +58,4 @@ DisableSyntax {
   noUniversalEquality = false
   regex = []
 }
+OrganizeImports.targetDialect = Scala3

--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,12 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(
   List(
-    tlBaseVersion := "0.7",
+    tlBaseVersion := "0.8",
     startYear := Some(2024),
     licenses := Seq(License.Apache2),
     organization := "org.soundsofscala",
     organizationName := "Sounds of Scala",
-    scalaVersion := "3.7.3",
+    scalaVersion := "3.8.2",
     dependencyOverrides += "org.scala-lang" %% "scala3-library" % scalaVersion.value,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
@@ -25,7 +25,7 @@ inThisBuild(
     tlFatalWarnings := sys.env.get("GITHUB_ACTIONS").contains("true"),
     tlCiScalafmtCheck := true,
     tlCiScalafixCheck := true,
-    tlJdkRelease := Some(8),
+    tlJdkRelease := Some(17),
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
     developers := List(
       tlGitHubDev("pauliamgiant", "Paul Matthews"),
@@ -73,12 +73,12 @@ lazy val sos = crossProject(JSPlatform, JVMPlatform)
     mimaPreviousArtifacts := Set.empty,
     moduleName := "sounds-of-scala",
     libraryDependencies ++= Seq(
-      "org.scalactic" %%% "scalactic" % "3.2.17",
-      "org.scalatest" %%% "scalatest" % "3.2.19" % Test,
+      "org.scalactic" %%% "scalactic" % "3.2.20",
+      "org.scalatest" %%% "scalatest" % "3.2.20" % Test,
       "org.typelevel" %%% "cats-core" % "2.13.0",
-      "org.typelevel" %%% "cats-effect" % "3.6.3",
-      "io.kevinlee" %%% "refined4s-core" % "1.1.0",
-      "io.kevinlee" %%% "refined4s-cats" % "1.1.0"
+      "org.typelevel" %%% "cats-effect" % "3.7.0",
+      "io.kevinlee" %%% "refined4s-core" % "1.16.0",
+      "io.kevinlee" %%% "refined4s-cats" % "1.16.0"
     )
   )
   .jvmSettings(
@@ -120,11 +120,12 @@ lazy val sos = crossProject(JSPlatform, JVMPlatform)
       processIndexHtml.value
       (Compile / fastOptJS).value
     },
-    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "2.8.0")
+    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "2.8.1")
   )
 
 lazy val docs =
   project.in(file("docs")).settings(
+    scalaVersion := "3.6.4",
     description := "Documentation for Sounds of Scala",
     mdocIn := file("docs/src/pages"),
     laikaTheme := Helium.defaults

--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
     </head>
     <body>
         <!-- Load Scala.js -->
-        <script src="/target/scala-3.7.3/sounds-of-scala-fastopt.js"></script>
+        <script src="/target/scala-3.8.2/sounds-of-scala-fastopt.js"></script>
     </body>
 </html>

--- a/js/app.css
+++ b/js/app.css
@@ -188,7 +188,7 @@ button {
 }
 
 .update-button {
-    background-color: #007bff;
+    background-color: #5ba8c8;
     color: white;
     border: none;
     padding: 15px 20px;
@@ -200,5 +200,34 @@ button {
 }
 
 .update-button:hover {
-    background-color: #0056b3;
+    background-color: #4a93b0;
+}
+
+.swing-button {
+    background-color: #5ba8c8;
+    color: white;
+    border: none;
+    padding: 15px 20px;
+    font-size: 1em;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    width: 5em;
+}
+
+.swing-button:hover {
+    background-color: #4a93b0;
+}
+
+.swing-display {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #2a2a2a;
+    color: #5ba8c8;
+    font-weight: bold;
+    font-size: 1.4em;
+    padding: 0.6em 1.5em;
+    border-radius: 6px;
+    margin-top: 0.8em;
 }

--- a/js/src/main/scala/org/soundsofscala/Main.scala
+++ b/js/src/main/scala/org/soundsofscala/Main.scala
@@ -53,6 +53,7 @@ object Main extends IOApp:
       quickStart <- buildSimpleAudioPlayerDirections
       introText <- buildIntroductionText
       beethovenText <- buildBeethovenText
+      swingText <- buildSwingText
       pagodasText <- buildPagodasText
       audioPlayerText <- buildAudioplayerText
       thingsToTry <- buildThingsToTry()
@@ -66,6 +67,10 @@ object Main extends IOApp:
       pagodas <- ExampleSong6.song()
       exampleSong1 <- ExampleSong1.song()
 
+      swingSong <- ExampleSong7SwingIt.song()
+      swingRef <- Ref.of[IO, Song](swingSong)
+      swingSequencer <- Sequencer(swingRef)
+
       song1Ref <- Ref.of[IO, Song](exampleSong1)
       song1Sequencer <- Sequencer(song1Ref)
 
@@ -75,7 +80,7 @@ object Main extends IOApp:
       pagodasRef <- Ref.of[IO, Song](pagodas)
       pagodasSequencer <- Sequencer(pagodasRef)
 
-      altKickPattern: MusicalEvent = C2.eighth + C2.eighth + RestQuarter.onFull
+      altKickPattern: MusicalEvent = (C2.eighth + C2.eighth + RestQuarter.onFull).repeat(32)
       exampleSong1ButtonGroup <- buildButtonGroup(
         label = "ExampleSong1",
         playAction = song1Sequencer.play(),
@@ -96,13 +101,47 @@ object Main extends IOApp:
         playAction = beethovenSequencer.play(),
         stopAction = beethovenSequencer.stop()
       )
+      swingDisplay <- IO {
+        val display = document.createElement("span")
+        display.classList.add("swing-display")
+        display.textContent = s"Swing: ${swingSong.swing.amount.value}"
+        display
+      }
+      swingButtonGroup <- buildButtonGroup(
+        label = "Swing Song",
+        playAction = swingSequencer.play(),
+        stopAction = swingSequencer.stop(),
+        extraActions = List(
+          (
+            "Swing +",
+            "swing-button",
+            swingRef.modify { song =>
+              val current = song.swing.amount.value
+              val next = Math.min(current + 1, 10)
+              val updated =
+                song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
+              (updated, next)
+            }.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v"))),
+          (
+            "Swing -",
+            "swing-button",
+            swingRef.modify { song =>
+              val current = song.swing.amount.value
+              val next = Math.max(current - 1, 0)
+              val updated =
+                song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
+              (updated, next)
+            }.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v")))
+        )
+      )
+      _ <- IO(swingButtonGroup.appendChild(swingDisplay))
       exampleSong5PagodasGroup <- buildButtonGroup(
         label = "ExampleSong5Pagodas",
         playAction = pagodasSequencer.play(),
         stopAction = pagodasSequencer.stop()
       )
       audioGraphButton <- buildButton(
-        label = "Audio Graph in action ▶",
+        label = "Audio Graph ▶",
         buttonAction = AudioGraphDemoCode.buildAudioGraphDemo
       )
 
@@ -117,6 +156,9 @@ object Main extends IOApp:
         document.createElement("hr"),
         beethovenText,
         beethovenButtonGroup,
+        document.createElement("hr"),
+        swingText,
+        swingButtonGroup,
         document.createElement("hr"),
         pagodasText,
         exampleSong5PagodasGroup,
@@ -203,6 +245,13 @@ object Main extends IOApp:
     beethovenText
   }
 
+  private def buildSwingText = IO {
+    val swingTestText = document.createElement("p")
+    swingTestText.textContent =
+      "Play this ExampleSong6Swing song to hear an example of Swing being applied to a Rhythm."
+    swingTestText
+  }
+
   private def buildPagodasText = IO {
     val pagodasText = document.createElement("p")
     pagodasText.textContent =
@@ -251,7 +300,7 @@ object Main extends IOApp:
 
       val listItem2 = document.createElement("li")
       listItem2.textContent =
-        "Try swapping out ExampleSong1 on line 83 with one of the other Song Examples in the songexamples package."
+        "Try swapping out ExampleSong1 on line 68 with one of the other Song Examples in the songexamples package."
       exampleList.append(listItem2)
 
       val listItem3 = document.createElement("li")
@@ -280,7 +329,7 @@ object Main extends IOApp:
           case "▶︎" => button.classList.add("play-button")
           case "◼︎" => button.classList.add("stop-button")
           case "⏸︎" => button.classList.add("audio-pause-button")
-          case _ => ()
+          case _ => button.classList.add("swing-button")
         button.addEventListener("click", (_: dom.MouseEvent) => buttonAction.unsafeRunAndForget())
         buttonContainer.appendChild(button)
       }
@@ -290,7 +339,8 @@ object Main extends IOApp:
       label: String,
       playAction: IO[Unit],
       stopAction: IO[Unit],
-      updateAction: Option[IO[Unit]] = None
+      updateAction: Option[IO[Unit]] = None,
+      extraActions: List[(String, String, IO[Unit])] = Nil
   ): IO[Element] =
     for
       groupContainer <- IO(document.createElement("div"))
@@ -333,6 +383,16 @@ object Main extends IOApp:
       _ <- IO(groupContainer.appendChild(labelElement))
       _ <- IO(groupContainer.appendChild(buttonContainer))
       _ <- IO(updateButton.foreach(buttonContainer.appendChild(_)))
+      _ <- extraActions.traverse_ {
+        case (text, cssClass, action) =>
+          IO {
+            val button = document.createElement("button")
+            button.textContent = text
+            button.classList.add(cssClass)
+            button.addEventListener("click", (_: dom.MouseEvent) => action.unsafeRunAndForget())
+            buttonContainer.appendChild(button)
+          }
+      }
     yield groupContainer
 
 end Main

--- a/js/src/main/scala/org/soundsofscala/graph/AudioGraphDemoCode.scala
+++ b/js/src/main/scala/org/soundsofscala/graph/AudioGraphDemoCode.scala
@@ -64,9 +64,8 @@ object AudioGraphDemoCode:
     // connect the nodes
     val graph = sawToothOsc --> bandpass --> gainNode
 
-    // create the graph
-    graph.create
-    ()
+    // play the graph
+    graph.play
   }
   end buildAudioGraphDemo
 

--- a/js/src/main/scala/org/soundsofscala/models/Song.scala
+++ b/js/src/main/scala/org/soundsofscala/models/Song.scala
@@ -21,7 +21,7 @@ import cats.data.NonEmptyList
 case class Song(
     title: Title,
     tempo: Tempo = Tempo(120),
-    swing: Swing = Swing(0),
+    swing: Swing = Swing(SwingAmount(0), SwingResolution.Eighth),
     mixer: Mixer
 )
 

--- a/js/src/main/scala/org/soundsofscala/models/Track.scala
+++ b/js/src/main/scala/org/soundsofscala/models/Track.scala
@@ -16,6 +16,7 @@
 
 package org.soundsofscala.models
 
+import cats.Eq
 import cats.effect.IO
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.instrument.Default
@@ -23,6 +24,9 @@ import org.soundsofscala.instrument.Instrument
 
 enum Playback:
   case Loop, OneShot
+
+object Playback:
+  given Eq[Playback] = Eq.fromUniversalEquals
 
 case class Track[Settings](
     title: Title,

--- a/js/src/main/scala/org/soundsofscala/playback/FunctionalAudioPlayer.scala
+++ b/js/src/main/scala/org/soundsofscala/playback/FunctionalAudioPlayer.scala
@@ -2,7 +2,6 @@ package org.soundsofscala.playback
 
 import cats.effect.{IO, Ref}
 import cats.syntax.all.*
-import org.scalajs.dom
 import org.scalajs.dom.{AudioBuffer, AudioBufferSourceNode, AudioContext, GainNode}
 import org.soundsofscala.instrument.SampleLoader
 import org.soundsofscala.models.{FilePath, PauseOffset, StartTime}

--- a/js/src/main/scala/org/soundsofscala/playback/SimpleAudioPlayer.scala
+++ b/js/src/main/scala/org/soundsofscala/playback/SimpleAudioPlayer.scala
@@ -3,7 +3,6 @@ package org.soundsofscala.playback
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
-import org.scalajs.dom
 import org.scalajs.dom.{AudioBuffer, AudioBufferSourceNode, AudioContext, GainNode}
 import org.soundsofscala.instrument.SampleLoader
 import org.soundsofscala.models.{PauseOffset, StartTime}

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong1.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong1.scala
@@ -98,7 +98,6 @@ object ExampleSong1:
     yield Song(
       title = Title("Song Example 1"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(
           Title("Kick"),

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong2.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong2.scala
@@ -45,7 +45,6 @@ object ExampleSong2:
     yield Song(
       title = Title("Rhubarb Loop"),
       tempo = Tempo(60),
-      swing = Swing(0),
       mixer = Mixer(
         Track(
           Title("rhubarb D3"),

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong3.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong3.scala
@@ -47,7 +47,6 @@ object ExampleSong3:
     yield Song(
       title = Title("Dissonant Twinkle Twinkle"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(Title("Single Synth Voice"), musicalEvent, guitar, Playback.OneShot))
     )

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong4.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong4.scala
@@ -41,7 +41,6 @@ object ExampleSong4:
     yield Song(
       title = Title("long note"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(Title("Live Bass"), musicalEvent, liveBass, Playback.OneShot),
         Track(Title("Scala Synth Line"), scalaSynthLine, scalaSynth, Playback.OneShot),

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong5Beethoven.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong5Beethoven.scala
@@ -154,7 +154,6 @@ object ExampleSong5Beethoven:
     yield Song(
       title = Title("Something We All Know"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(
           Title("Beethoven Upper Voice"),

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
@@ -28,7 +28,6 @@ object ExampleSong6:
     yield Song(
       title = Title("Laideronnette, impératrice des pagodes"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(
           Title("Laideronnette, impératrice des pagodes"),

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong7SwingIt.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong7SwingIt.scala
@@ -1,0 +1,69 @@
+package org.soundsofscala.songexamples
+
+import cats.effect.IO
+import cats.syntax.all.*
+import org.scalajs.dom.AudioContext
+import org.soundsofscala.instrument.*
+import org.soundsofscala.models.*
+import org.soundsofscala.models.Playback
+import org.soundsofscala.syntax.all.*
+
+object ExampleSong7SwingIt:
+
+  private val drumSamplerSettings: SamplePlayer.Settings =
+    SamplePlayer.Settings(
+      volume = 0.8,
+      playbackRate = 1,
+      reversed = false,
+      loop = none,
+      fadeIn = 0,
+      fadeOut = 0,
+      startDelay = 0,
+      offset = 0,
+      length = none
+    )
+
+  val kickDrum: MusicalEvent = (C2 + RestQuarter.onFull).repeat(32)
+  val snareDrum: MusicalEvent = (RestQuarter + D2).repeat(32)
+  val hiHats: MusicalEvent = (E2.eighth.medium * 8).repeat(32)
+
+  private def drumSampler(): AudioContext ?=> IO[Sampler] = Sampler.fromPaths(
+    List(
+      SampleKey(Pitch.C, Accidental.Natural, Octave(2)) -> "resources/audio/drums/KickDrum.wav",
+      SampleKey(Pitch.D, Accidental.Natural, Octave(2)) -> "resources/audio/drums/SnareDrum.wav",
+      SampleKey(
+        Pitch.E,
+        Accidental.Natural,
+        Octave(2)) -> "resources/audio/drums-electro/HatsVintageElectro.wav"
+    )
+  )
+
+  def song(): AudioContext ?=> IO[Song] =
+    for
+      drums <- drumSampler()
+    yield Song(
+      title = Title("Song Example 7 with Swing"),
+      tempo = Tempo(120),
+      swing = Swing(SwingAmount(5), SwingResolution.Eighth),
+      mixer = Mixer(
+        Track(
+          Title("Kick"),
+          kickDrum,
+          drums,
+          Playback.Loop,
+          customSettings = drumSamplerSettings.some),
+        Track(
+          Title("Snare"),
+          snareDrum,
+          drums,
+          Playback.Loop,
+          customSettings = drumSamplerSettings.some),
+        Track(
+          Title("Hats"),
+          hiHats,
+          drums,
+          Playback.Loop,
+          customSettings = drumSamplerSettings.some)
+      )
+    )
+end ExampleSong7SwingIt

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSongSampler.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSongSampler.scala
@@ -73,7 +73,6 @@ object ExampleSongSampler:
     yield Song(
       title = Title("Rhubarb"),
       tempo = Tempo(110),
-      swing = Swing(0),
       mixer = Mixer(
         Track(Title("RhubarbHigh"), rhubarbHigh, rhubarb, Playback.OneShot),
         Track(Title("RhubarbLow"), rhubarbLow, rhubarb, Playback.OneShot),

--- a/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
@@ -21,6 +21,7 @@ import cats.effect.Ref
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.models.*
 
+import scala.annotation.tailrec
 import scala.concurrent.duration.DurationDouble
 
 /**
@@ -36,49 +37,198 @@ import scala.concurrent.duration.DurationDouble
  * @param scheduleAheadTimeSeconds
  *   The time window in seconds in which to schedule notes ahead of time
  */
+
+private case class ScheduleContext(
+    trackIndex: TrackIndex,
+    initialEvent: MusicalEvent,
+    remainingEvent: MusicalEvent,
+    nextNoteTime: NextNoteTime,
+    beatPosition: BeatPosition,
+    swingCompensation: SwingOffset
+)
+
 final case class NoteScheduler(
     songRef: Ref[IO, Song],
     lookAheadMs: LookAhead,
     scheduleAheadTimeSeconds: ScheduleWindow):
 
-  def scheduleTrack(trackIndex: Int)(using ac: AudioContext): IO[Unit] =
-    def loop(nextNoteTime: NextNoteTime): IO[Unit] =
+  def scheduleTrack(trackIndex: TrackIndex)(using ac: AudioContext): IO[Unit] =
+    def playCycle(nextNoteTime: NextNoteTime): IO[Unit] =
       for
         song <- songRef.get
-        track = song.mixer.tracks.toList(trackIndex)
-        finalNoteTime <- scheduleSequence(
-          track,
-          track.musicalEvent,
-          nextNoteTime)
+        track = song.mixer.tracks.toList(trackIndex.value)
+        scheduleContext = ScheduleContext(
+          trackIndex,
+          initialEvent = track.musicalEvent,
+          remainingEvent = track.musicalEvent,
+          nextNoteTime,
+          BeatPosition(0.0),
+          SwingOffset(0.0))
+        finalNoteTime <- scheduleSequence(scheduleContext)
         _ <-
-          if track.playback == Playback.Loop
-          then loop(finalNoteTime)
-          else IO.unit
+          track.playback match
+            case Playback.Loop => playCycle(finalNoteTime)
+            case Playback.OneShot => IO.unit
       yield ()
 
-    loop(NextNoteTime(ac.currentTime))
+    playCycle(NextNoteTime(ac.currentTime))
 
-  private def scheduleSequence(
-      track: Track[?],
-      musicalEvent: MusicalEvent,
-      nextNoteTime: NextNoteTime)(using AudioContext): IO[NextNoteTime] =
-    ScheduleStatus(nextNoteTime, scheduleAheadTimeSeconds) match
-      case ScheduleStatus.Ready =>
-        songRef.get.flatMap: song =>
-          val tempo = song.tempo
-          musicalEvent match
-            case sequence: Sequence =>
-              val nextNextNoteTime =
-                NextNoteTime(nextNoteTime.value + sequence.head.durationToSeconds(tempo))
-              track.playAtomicMusicalEvent(sequence.head, nextNoteTime.value, tempo) >>
-                scheduleSequence(track, sequence.tail, nextNextNoteTime)
-            case atomicEvent: AtomicMusicalEvent =>
-              val nextNextNoteTime =
-                NextNoteTime(nextNoteTime.value + atomicEvent.durationToSeconds(tempo))
-              track.playAtomicMusicalEvent(atomicEvent, nextNoteTime.value, tempo)
-                .as(nextNextNoteTime)
-
+  private def scheduleSequence(context: ScheduleContext)(using AudioContext): IO[NextNoteTime] =
+    ScheduleStatus.isReadyToSchedule(context.nextNoteTime, scheduleAheadTimeSeconds) match
       case ScheduleStatus.Waiting =>
-        IO.sleep(lookAheadMs.value.millis) >>
-          scheduleSequence(track, musicalEvent, nextNoteTime)
+        IO.sleep(lookAheadMs.value.millis) >> scheduleSequence(context)
+      case ScheduleStatus.Ready =>
+        // read latest version of the song
+        songRef.get.flatMap: song =>
+          val track = song.mixer.tracks.toList(context.trackIndex.value)
+          val currentEventFromSongRef = track.musicalEvent
+
+          // this compares the event from the song ref with the original event specified when the song started playing
+          if currentEventFromSongRef != context.initialEvent
+            // If changed then updated sequence and call this scheduleSequence method again
+          then applyLiveUpdate(context, currentEventFromSongRef, song)
+          else playNextNote(context, song)
+
+  private def playNextNote(context: ScheduleContext, song: Song)(
+      using AudioContext): IO[NextNoteTime] =
+    val track = song.mixer.tracks.toList(context.trackIndex.value)
+    val swingInMillis = calculateSwingOffset(song)
+
+    def calculateNextNoteTime(note: AtomicMusicalEvent, swingOffset: Double): NextNoteTime =
+      NextNoteTime(
+        context.nextNoteTime.value + swingOffset + context.swingCompensation.value + note
+          .durationToSeconds(song.tempo))
+
+    context.remainingEvent match
+      case sequence: Sequence =>
+        val updatedBeatPosition = incrementBeatPosition(context.beatPosition, sequence.head)
+        val swingOffset =
+          if updatedBeatPosition.isSwungBeat(song.swing) then swingInMillis else 0.0
+        val nextNextNoteTime = calculateNextNoteTime(sequence.head, swingOffset)
+        track.playAtomicMusicalEvent(sequence.head, context.nextNoteTime.value, song.tempo) >>
+          scheduleSequence(context.copy(
+            remainingEvent = sequence.tail,
+            nextNoteTime = nextNextNoteTime,
+            beatPosition = updatedBeatPosition,
+            swingCompensation = SwingOffset.compensation(swingOffset)))
+      case atomicEvent: AtomicMusicalEvent =>
+        val nextNextNoteTime = calculateNextNoteTime(atomicEvent, swingOffset = 0.0)
+        track.playAtomicMusicalEvent(atomicEvent, context.nextNoteTime.value, song.tempo)
+          // at the very end of the sequence we return the time of the final note so we can
+          // use this for Playback.Loop
+          .as(nextNextNoteTime)
+  end playNextNote
+
+  private def applyLiveUpdate(
+      context: ScheduleContext,
+      updatedEvent: MusicalEvent,
+      song: Song
+  )(using AudioContext): IO[NextNoteTime] =
+    // updatedEvent is the whole new musicalEvent from the start so we need to locate where to start from
+    val (eventFromCurrentPosition, currentBeatPosition) =
+      findEventAtBeatPosition(updatedEvent, context.beatPosition)
+
+    val adjustedNoteTime = adjustNoteTimeForBeatOffset(
+      context.nextNoteTime,
+      context.beatPosition,
+      currentBeatPosition,
+      song.tempo)
+
+    // call schedule sequence again with event from current position & timing
+    scheduleSequence(context.copy(
+      initialEvent = updatedEvent,
+      remainingEvent = eventFromCurrentPosition,
+      nextNoteTime = adjustedNoteTime,
+      beatPosition = currentBeatPosition
+    ))
+
+  /*
+  Compensating - Event Boundary
+
+  A Mismatch happens when two tracks have different subdivision patterns
+  I found this with the hi-hats being 8ths and kick being quarter notes
+
+  Say you resume or create a live update at beat 3.5
+
+  Kick (quarter notes, boundaries at 0, 1, 2, 3, 4):
+  findEventAtBeatPosition walks: 0 → 1 → 2 → 3 (3 < 3.5, keep going) → 4 (4 >= 3.5, stop).
+  Lands at beat 4.0.
+
+  Hihats (eighth notes, boundaries at 0, 0.5, 1.0, ... 3.0, 3.5, 4.0):
+  Walks: 0 → 0.5 → ... → 3.0 → 3.5 (3.5 >= 3.5, stop). Lands at beat 3.5.
+
+  Without the adjustment, both would play their first note at the same AudioContext.currentTime
+  but the kick is at beat 4.0 and the hihat is at beat 3.5.
+  That's half a beat apart, so they'd be out of sync.
+
+  adjustNoteTimeForBeatOffset fixes it: the kick landed 0.5 beats past the target,
+  so its first note gets pushed forward by 0.5 beats worth of seconds.
+  Now the kick plays at the correct time for beat 4.0 and the hihat
+  at the correct time for beat 3.5.
+
+  This method compensates for that gap.
+  It takes the difference between where you landed (actualBeatPosition)
+  and where you wanted to be (expectedBeatPosition), converts that from
+  beats to seconds using the tempo, and shifts noteTime forward by that amount.
+  So the note plays at the correct AudioContext time for the beat it's actually at.
+   */
+  private def adjustNoteTimeForBeatOffset(
+      noteTime: NextNoteTime,
+      expectedBeatPosition: BeatPosition,
+      actualBeatPosition: BeatPosition,
+      tempo: Tempo): NextNoteTime =
+    val beatOffset = actualBeatPosition.value - expectedBeatPosition.value
+    val secondsPerBeat = 60.0 / tempo.value
+    NextNoteTime(noteTime.value + beatOffset * secondsPerBeat)
+  end adjustNoteTimeForBeatOffset
+
+  /*
+  Iterates through sequence from start - Returns the remaining sequence
+  from that point and the beat position where it landed.
+
+  Used for two things:
+  1. Looking for position in sequence on resume
+  2. finding where to continue in a new pattern after a live update.
+   */
+  private def findEventAtBeatPosition(
+      event: MusicalEvent,
+      targetBeatPosition: BeatPosition
+  ): (MusicalEvent, BeatPosition) =
+    @tailrec
+    def loop(
+        current: MusicalEvent,
+        beatPositionAccumulator: BeatPosition): (MusicalEvent, BeatPosition) =
+      current match
+        case sequence: Sequence =>
+          if beatPositionAccumulator.value >= targetBeatPosition.value
+          then (current, beatPositionAccumulator)
+          else
+            loop(
+              sequence.tail,
+              BeatPosition(beatPositionAccumulator.value + sequence.head.durationToBeats))
+        case atomic: AtomicMusicalEvent =>
+          (atomic, beatPositionAccumulator)
+    // start from the beginning and find event at targetBeatPosition
+    loop(event, BeatPosition(0.0))
+
+  private def calculateSwingOffset(song: Song): Double =
+    val swingFromTempo = song.swing.amount.value.toDouble / 1000.0 * (60.0 / song.tempo.value)
+    song.swing.resolution match
+      case SwingResolution.Eighth => swingFromTempo * 20
+      case SwingResolution.Sixteenth => swingFromTempo * 16
+
+  private def incrementBeatPosition(
+      currentBeatPosition: BeatPosition,
+      note: AtomicMusicalEvent): BeatPosition =
+    val durationInBeats = note.durationToBeats
+    BeatPosition(currentBeatPosition.value + durationInBeats)
+
+  extension (beatPosition: BeatPosition)
+    def isSwungBeat(swing: Swing): Boolean =
+      val beatSubdivision = beatPosition.value % 1.0
+      swing.resolution match
+        case SwingResolution.Eighth => beatSubdivision >= 0.5 && beatSubdivision < 1.0
+        case SwingResolution.Sixteenth => beatSubdivision >= 0.25 && beatSubdivision < 0.5 ||
+          beatSubdivision >= 0.75 && beatSubdivision < 1.0
+
 end NoteScheduler

--- a/js/src/main/scala/org/soundsofscala/transport/ScheduleStatus.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/ScheduleStatus.scala
@@ -25,7 +25,7 @@ enum ScheduleStatus:
   case Waiting extends ScheduleStatus
 
 private object ScheduleStatus:
-  def apply(nextNoteTime: NextNoteTime, scheduleAheadTimeSeconds: ScheduleWindow)(using
+  def isReadyToSchedule(nextNoteTime: NextNoteTime, scheduleAheadTimeSeconds: ScheduleWindow)(using
   audioContext: AudioContext): ScheduleStatus =
     if nextNoteTime.value < audioContext.currentTime + scheduleAheadTimeSeconds.value then
       Ready

--- a/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
@@ -24,6 +24,7 @@ import org.scalajs.dom.AudioContext
 import org.soundsofscala.models.LookAhead
 import org.soundsofscala.models.ScheduleWindow
 import org.soundsofscala.models.Song
+import org.soundsofscala.models.TrackIndex
 
 /**
  * The sequencer is responsible for scheduling the notes of every track in the song in parallel. It
@@ -55,7 +56,7 @@ class Sequencer private (
   def stop(): IO[Unit] =
     fiberRef.getAndSet(none).flatMap:
       case Some(fiber) =>
-        IO.println("Cancelling running sequencer") *>
+        IO.println("Stopping sequencer") *>
           fiber.cancel *>
           stopInstruments()
       case none => IO.unit
@@ -66,14 +67,11 @@ class Sequencer private (
   private def startPlayback(): IO[Unit] =
     songRef.get.flatMap: song =>
       val noteScheduler = NoteScheduler(songRef, LookAhead(25), ScheduleWindow(0.1))
-      song
-        .mixer
-        .tracks
-        .toList
-        .zipWithIndex
-        .parTraverse: (_, index) =>
-          noteScheduler.scheduleTrack(index)
-        .void *>
+      /* create indexes for each track so the scheduler can re-read the track from the
+      songRef on every note — this enables live updates */
+      song.mixer.tracks.zipWithIndex.parTraverse: (_, index) =>
+        noteScheduler.scheduleTrack(TrackIndex(index))
+      .void *>
         songRef.get.flatMap(s => IO.println(s"Finished playing: ${s.title}"))
 end Sequencer
 

--- a/shared/src/main/scala/org/soundsofscala/models/Duration.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/Duration.scala
@@ -51,6 +51,28 @@ enum Duration:
 
   private val oneThird: Double = 1d / 3d
 
+  def toBeats: Double = this match
+    case Duration.Whole => 4.0
+    case Duration.Half => 2.0
+    case Duration.Quarter => 1.0
+    case Duration.Eighth => 0.5
+    case Duration.Sixteenth => 0.25
+    case Duration.ThirtySecond => 0.125
+    case Duration.SixtyFourth => 0.0625
+    // Triplets
+    case Duration.HalfTriplet => 4.0 * oneThird
+    case Duration.QuarterTriplet => 2.0 * oneThird
+    case Duration.EighthTriplet => 1.0 * oneThird
+    case Duration.SixteenthTriplet => 0.5 * oneThird
+    case Duration.ThirtySecondTriplet => 0.25 * oneThird
+    // Dotteds
+    case Duration.WholeDotted => 4.0 * 1.5
+    case Duration.HalfDotted => 2.0 * 1.5
+    case Duration.QuarterDotted => 1.0 * 1.5
+    case Duration.EighthDotted => 0.5 * 1.5
+    case Duration.SixteenthDotted => 0.25 * 1.5
+    case Duration.ThirtySecondDotted => 0.125 * 1.5
+
   def toSeconds(tempo: Tempo): Double =
     val secondsPerBeat = 60.0 / tempo.value
     this match

--- a/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
@@ -113,6 +113,8 @@ enum AtomicMusicalEvent(duration: Duration, velocity: Velocity) extends MusicalE
   def durationToSeconds(tempo: Tempo): Double =
     this.duration.toSeconds(tempo)
 
+  def durationToBeats: Double = this.duration.toBeats
+
   def normalizedVelocity: Double = this.velocity.getNormalisedVelocity
 
   override def toString: String =

--- a/shared/src/main/scala/org/soundsofscala/models/Types.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/Types.scala
@@ -16,6 +16,7 @@
 
 package org.soundsofscala.models
 
+import refined4s.CanBeOrdered
 import refined4s.Newtype
 import refined4s.Refined
 
@@ -61,9 +62,24 @@ object Tempo extends Newtype[Double]
 type IsLooping = IsLooping.Type
 object IsLooping extends Newtype[Boolean]
 
-type Swing = Swing.Type
+type BeatPosition = BeatPosition.Type
+object BeatPosition extends Newtype[Double] with CanBeOrdered[Double]
 
-object Swing extends Refined[Int]:
+type TrackIndex = TrackIndex.Type
+object TrackIndex extends Newtype[Int] with CanBeOrdered[Int]
+
+type SwingOffset = SwingOffset.Type
+object SwingOffset extends Newtype[Double]:
+  def compensation(swingOffset: Double): SwingOffset = SwingOffset(-swingOffset)
+
+final case class Swing(amount: SwingAmount, resolution: SwingResolution)
+
+enum SwingResolution:
+  case Eighth
+  case Sixteenth
+
+type SwingAmount = SwingAmount.Type
+object SwingAmount extends Refined[Int]:
   override inline def invalidReason(s: Int): String =
     expectedMessage("is an Int between 0 and 10. 0 is totally straight. 10 is very swung.")
 


### PR DESCRIPTION
SOS-060: Add swing feature with real-time song updates

**Bumps deps:** Scala 3.8.2 , Cats Effect 3.7.0

**Swing model refactor:**

- Refactored Swing from a simple Refined[Int] to a case class Swing(amount: SwingAmount, resolution: SwingResolution), supporting both eighth and sixteenth note swing
- Added SwingAmount (refined 0-10), SwingResolution enum (Eighth/Sixteenth), and SwingOffset with a compensation factory method

**NoteScheduler refactor:**

Introduced ScheduleContext case class to bundle scheduling data, replacing long parameter lists threaded through recursive calls

**Real-time live updates:**

NoteScheduler now re-reads the song Ref on every scheduling cycle, comparing the current track event against the initial event
When a change is detected, applyLiveUpdate goes to the equivalent beat position in the new pattern, preserving timing alignment with other tracks
Works for both Loop and OneShot playback modes

**Swing scheduling:**

Swing offsets are applied to offbeat notes (eighth or sixteenth resolution) proportional to beat length (60/tempo)
Swing compensation on the following note preserves bar duration
Sixteenth swing correctly targets the "e" and "a" subdivisions

**New example song:**

Added ExampleSong7SwingIt — a drum pattern with kick, snare, and hi-hats demonstrating swing at tempo 120

**Demo UI:**

Added Swing +/- buttons to the Swing Song button group with real-time Ref.modify updates
Added a swing amount display panel that updates live when adjusting swing