### PR TITLE
Add pause/resume, click track, beat display and bump build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
           path: targets.tar
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -123,7 +123,7 @@ jobs:
         run: sbt +update
 
       - name: Download target directories (3)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -211,7 +211,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ inThisBuild(
     licenses := Seq(License.Apache2),
     organization := "org.soundsofscala",
     organizationName := "Sounds of Scala",
-    scalaVersion := "3.8.2",
+    scalaVersion := "3.8.4",
     dependencyOverrides += "org.scala-lang" %% "scala3-library" % scalaVersion.value,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
@@ -31,7 +31,8 @@ inThisBuild(
       tlGitHubDev("pauliamgiant", "Paul Matthews"),
       tlGitHubDev("noelwelsh", "Noel Welsh"),
       tlGitHubDev("ikukojohanna", "Johanna Odersky"),
-      tlGitHubDev("BokChoyWarrior", "Harvey Cambridge")
+      tlGitHubDev("BokChoyWarrior", "Harvey Cambridge"),
+      tlGitHubDev("SabrinaXKL", "Sabrina Konrad-lee")
     ),
     scalafixDependencies ++= List(
       "com.github.xuwei-k" %% "scalafix-rules" % "0.3.0"
@@ -199,7 +200,7 @@ usefulTasks := Seq(
         "Pre-push formatting and testing checks",
       ).alias("pp"),
   UsefulTask("dependencyUpdates", "Run dependencyUpdates").alias("du"),
-  UsefulTask("headerCreate", "Run create headers for pagers to pass ci").alias("h")
+  UsefulTask("headerCreate", "Run create headers for pages to pass ci").alias("h")
 )
 
 logoColor := scala.Console.YELLOW

--- a/docs/src/pages/README.md
+++ b/docs/src/pages/README.md
@@ -8,7 +8,7 @@ Sounds of Scala is available for Scala 3.2+. You can add Sounds of Scala to your
 
 ```scala 3
 libraryDependencies ++= Seq(
-  "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0")
+  "org.soundsofscala" %%% "sounds-of-scala" % "0.8.1")
 ```
 
 ### [Next Step: Getting Started](http://127.0.0.1:4242/getting-started/)

--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
     </head>
     <body>
         <!-- Load Scala.js -->
-        <script src="/target/scala-3.8.2/sounds-of-scala-fastopt.js"></script>
+        <script src="/target/scala-3.8.4/sounds-of-scala-fastopt.js"></script>
     </body>
 </html>

--- a/js/src/main/scala/org/soundsofscala/Main.scala
+++ b/js/src/main/scala/org/soundsofscala/Main.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.soundsofscala
 
 import cats.data.NonEmptyList
 import cats.effect.Ref
 import cats.effect.unsafe.implicits.global
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{ExitCode, Fiber, IO, IOApp}
 import cats.syntax.all.*
 import org.scalajs.dom
 import org.scalajs.dom.*
@@ -28,6 +29,27 @@ import org.soundsofscala.playback.AudioPlayer
 import org.soundsofscala.songexamples.*
 import org.soundsofscala.syntax.all.*
 import org.soundsofscala.transport.Sequencer
+
+import scala.concurrent.duration.DurationInt
+
+extension (ref: Ref[IO, Song])
+  def swingUp: IO[Int] =
+    ref.modify { song =>
+      val current = song.swing.amount.value
+      val next = Math.min(current + 1, 10)
+      val updated =
+        song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
+      (updated, next)
+    }
+
+  def swingDown: IO[Int] =
+    ref.modify { song =>
+      val current = song.swing.amount.value
+      val next = Math.max(current - 1, 0)
+      val updated =
+        song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
+      (updated, next)
+    }
 
 object Main extends IOApp:
 
@@ -42,9 +64,27 @@ object Main extends IOApp:
       )
     }.as(ExitCode.Success)
 
+  // Display polling loop
+
+  def updateDisplay(song1Sequencer: Sequencer, beatPositionDisplay: Element) =
+    song1Sequencer.currentBeatPosition.flatMap(beatPosition =>
+      IO(beatPositionDisplay.textContent = f"Beat: ${beatPosition.value + 0.5}%.2f"))
+
+  def startDisplayLoop(
+      displayFiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+      sequencer: Sequencer,
+      beatPositionDisplay: Element) =
+    ((updateDisplay(sequencer, beatPositionDisplay) >> IO.sleep(100.millis)).foreverM: IO[
+      Unit]).start
+      .flatMap(fiber => displayFiberRef.set(fiber.some))
+
+  def stopDisplayLoop(displayFiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]]) =
+    displayFiberRef.getAndSet(none).flatMap(_.fold(IO.unit)(_.cancel))
+
   private def setupPage(): AudioContext ?=> IO[Unit] =
     for
       audioPlayer <- AudioPlayer(FilePath("resources/audio/sounds-of-scala.mp3"))
+      displayFiberRef <- Ref.of[IO, Option[Fiber[IO, Throwable, Unit]]](none)
 
       homeDiv <- IO(document.createElement("div"))
       _ <- IO(homeDiv.classList.add("home-div"))
@@ -63,16 +103,16 @@ object Main extends IOApp:
       stopButton <- buildButton(label = "◼︎", buttonAction = audioPlayer.stop())
       pauseButton <- buildButton(label = "⏸︎", buttonAction = audioPlayer.pause())
 
+      exampleSong1 <- ExampleSong1.song()
+      song1Ref <- Ref.of[IO, Song](exampleSong1)
+      song1Sequencer <- Sequencer(song1Ref)
+
       beethovenSong <- ExampleSong5Beethoven.song()
       pagodas <- ExampleSong6.song()
-      exampleSong1 <- ExampleSong1.song()
 
       swingSong <- ExampleSong7SwingIt.song()
       swingRef <- Ref.of[IO, Song](swingSong)
       swingSequencer <- Sequencer(swingRef)
-
-      song1Ref <- Ref.of[IO, Song](exampleSong1)
-      song1Sequencer <- Sequencer(song1Ref)
 
       beethovenRef <- Ref.of[IO, Song](beethovenSong)
       beethovenSequencer <- Sequencer(beethovenRef)
@@ -81,21 +121,23 @@ object Main extends IOApp:
       pagodasSequencer <- Sequencer(pagodasRef)
 
       altKickPattern: MusicalEvent = (C2.eighth + C2.eighth + RestQuarter.onFull).repeat(32)
+      beatPositionDisplay <- IO {
+        val display = document.createElement("span")
+        display.classList.add("swing-display")
+        display.textContent = "Beat: 1.00"
+        display
+      }
+
       exampleSong1ButtonGroup <- buildButtonGroup(
         label = "ExampleSong1",
-        playAction = song1Sequencer.play(),
-        stopAction = song1Sequencer.stop(),
-        updateAction = song1Ref.modify { song =>
-          val kick = song.mixer.tracks.head
-          val (newEvent, label) =
-            if kick.musicalEvent == ExampleSong1.kickDrum
-            then (altKickPattern, "double kick")
-            else (ExampleSong1.kickDrum, "original")
-          val updatedSong = song.copy(
-            mixer = Mixer(NonEmptyList(kick.withMusicalEvent(newEvent), song.mixer.tracks.tail)))
-          (updatedSong, label)
-        }.flatMap(label => IO.println(s"Kick pattern: $label")).some
+        playAction = song1PlayAction(song1Sequencer, displayFiberRef, beatPositionDisplay),
+        stopAction = song1StopAction(song1Sequencer, displayFiberRef, beatPositionDisplay),
+        extraActions = song1ExtraActions(song1Ref, song1Sequencer),
+        pauseAction = song1PauseAction(song1Sequencer, displayFiberRef, beatPositionDisplay).some,
+        updateAction = toggleKickAction(song1Ref, altKickPattern).some
       )
+      _ <- IO(exampleSong1ButtonGroup.appendChild(beatPositionDisplay))
+
       beethovenButtonGroup <- buildButtonGroup(
         label = "ExampleSong4Beethoven",
         playAction = beethovenSequencer.play(),
@@ -111,28 +153,7 @@ object Main extends IOApp:
         label = "Swing Song",
         playAction = swingSequencer.play(),
         stopAction = swingSequencer.stop(),
-        extraActions = List(
-          (
-            "Swing +",
-            "swing-button",
-            swingRef.modify { song =>
-              val current = song.swing.amount.value
-              val next = Math.min(current + 1, 10)
-              val updated =
-                song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
-              (updated, next)
-            }.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v"))),
-          (
-            "Swing -",
-            "swing-button",
-            swingRef.modify { song =>
-              val current = song.swing.amount.value
-              val next = Math.max(current - 1, 0)
-              val updated =
-                song.copy(swing = Swing(SwingAmount.unsafeFrom(next), song.swing.resolution))
-              (updated, next)
-            }.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v")))
-        )
+        extraActions = swingExtraActions(swingRef, swingDisplay)
       )
       _ <- IO(swingButtonGroup.appendChild(swingDisplay))
       exampleSong5PagodasGroup <- buildButtonGroup(
@@ -173,9 +194,70 @@ object Main extends IOApp:
     end for
   end setupPage
 
+  private def song1PlayAction(
+      sequencer: Sequencer,
+      displayFiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+      beatPositionDisplay: Element): IO[Unit] =
+    sequencer.play() *> startDisplayLoop(displayFiberRef, sequencer, beatPositionDisplay)
+
+  private def song1StopAction(
+      sequencer: Sequencer,
+      displayFiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+      beatPositionDisplay: Element): IO[Unit] =
+    stopDisplayLoop(displayFiberRef) *> sequencer.stop() *>
+      IO(beatPositionDisplay.textContent = "Beat: 1.00")
+
+  private def song1PauseAction(
+      sequencer: Sequencer,
+      displayFiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+      beatPositionDisplay: Element): IO[Unit] =
+    stopDisplayLoop(displayFiberRef) *> sequencer.pause() *>
+      updateDisplay(sequencer, beatPositionDisplay)
+
+  private def song1ExtraActions(
+      songRef: Ref[IO, Song],
+      sequencer: Sequencer): List[(String, String, IO[Unit])] =
+    List(
+      ("Swing +", "swing-button", songRef.swingUp.void),
+      ("Swing -", "swing-button", songRef.swingDown.void),
+      (
+        "🕰️",
+        "swing-button",
+        sequencer.toggleClick.flatMap(muted =>
+          IO.println(s"Click track: ${if muted then "off" else "on"}")))
+    )
+
+  private def toggleKickAction(
+      songRef: Ref[IO, Song],
+      altKickPattern: MusicalEvent): IO[Unit] =
+    songRef.modify { song =>
+      val kick = song.mixer.tracks.head
+      val (newEvent, label) =
+        if kick.musicalEvent == ExampleSong1.kickDrum
+        then (altKickPattern, "double kick")
+        else (ExampleSong1.kickDrum, "original")
+      val updatedSong = song.copy(
+        mixer = Mixer(NonEmptyList(kick.withMusicalEvent(newEvent), song.mixer.tracks.tail)))
+      (updatedSong, label)
+    }.flatMap(label => IO.println(s"Kick pattern: $label"))
+
+  private def swingExtraActions(
+      swingRef: Ref[IO, Song],
+      swingDisplay: Element): List[(String, String, IO[Unit])] =
+    List(
+      (
+        "Swing +",
+        "swing-button",
+        swingRef.swingUp.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v"))),
+      (
+        "Swing -",
+        "swing-button",
+        swingRef.swingDown.flatMap(v => IO(swingDisplay.textContent = s"Swing: $v")))
+    )
+
   private def buildHeading = IO {
     val title = document.createElement("h1")
-    title.textContent = "Welcome to Sounds of Scala!"
+    title.textContent = "Welcome to Sounds of Scala"
     title
   }
 
@@ -195,7 +277,7 @@ object Main extends IOApp:
 
     val codeStringSbt: String =
       """|
-         |"libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0""".stripMargin
+         |"libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.9.0""".stripMargin
 
     val addToCode = document.createElement("p")
     addToCode.textContent =
@@ -339,8 +421,9 @@ object Main extends IOApp:
       label: String,
       playAction: IO[Unit],
       stopAction: IO[Unit],
-      updateAction: Option[IO[Unit]] = None,
-      extraActions: List[(String, String, IO[Unit])] = Nil
+      updateAction: Option[IO[Unit]] = none,
+      extraActions: List[(String, String, IO[Unit])] = Nil,
+      pauseAction: Option[IO[Unit]] = none
   ): IO[Element] =
     for
       groupContainer <- IO(document.createElement("div"))
@@ -369,11 +452,20 @@ object Main extends IOApp:
         stopButton.addEventListener("click", (_: dom.MouseEvent) => stopAction.unsafeRunAndForget())
       }
 
-      updateButton <- updateAction.fold(IO.pure(None))(action =>
+      pauseButton <- pauseAction.fold(IO.pure(none))(action =>
         for
           button <- IO(document.createElement("button"))
           _ <- IO {
-            button.textContent = "update - realtime"
+            button.textContent = "⏸︎"
+            button.classList.add("audio-pause-button")
+            button.addEventListener("click", (_: dom.MouseEvent) => action.unsafeRunAndForget())
+          }
+        yield button.some)
+      updateButton <- updateAction.fold(IO.pure(none))(action =>
+        for
+          button <- IO(document.createElement("button"))
+          _ <- IO {
+            button.textContent = "realtime update kick"
             button.classList.add("update-button")
             button.addEventListener("click", (_: dom.MouseEvent) => action.unsafeRunAndForget())
           }
@@ -383,6 +475,8 @@ object Main extends IOApp:
       _ <- IO(groupContainer.appendChild(labelElement))
       _ <- IO(groupContainer.appendChild(buttonContainer))
       _ <- IO(updateButton.foreach(buttonContainer.appendChild(_)))
+      _ <- IO(pauseButton.foreach(buttonContainer.appendChild(_)))
+
       _ <- extraActions.traverse_ {
         case (text, cssClass, action) =>
           IO {

--- a/js/src/main/scala/org/soundsofscala/graph/AudioGraphDemoCode.scala
+++ b/js/src/main/scala/org/soundsofscala/graph/AudioGraphDemoCode.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.graph
 
 import cats.effect.IO

--- a/js/src/main/scala/org/soundsofscala/instrument/ClickTrack.scala
+++ b/js/src/main/scala/org/soundsofscala/instrument/ClickTrack.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.soundsofscala.instrument
+
+import cats.effect.{IO, Ref}
+import org.scalajs.dom
+import org.scalajs.dom.{AudioContext, AudioNode}
+import org.soundsofscala.graph.AudioNode.*
+import org.soundsofscala.graph.AudioParam
+import org.soundsofscala.graph.AudioParam.AudioParamEvent.*
+import org.soundsofscala.models.*
+import org.soundsofscala.syntax.all.*
+
+object ClickTrack:
+  case class Settings(volume: Double = 0.3, frequency: Double = 1000.0)
+
+  given Default[Settings] with
+    val default: Settings = Settings()
+
+  val pattern: MusicalEvent = C4.medium.eighth * 8
+
+  def track(instrument: ClickTrack): Track[Settings] =
+    Track(Title("ClickTrack"), pattern, instrument, Playback.Loop)
+
+  def apply()(using audioContext: AudioContext): IO[ClickTrack] =
+    for
+      activeNodesRef <- Ref.of[IO, Set[AudioNode]](Set.empty)
+      mutedRef <- Ref.of[IO, Boolean](true)
+    yield new ClickTrack(activeNodesRef, mutedRef)
+end ClickTrack
+
+final class ClickTrack private (
+    protected val activeNodesRef: Ref[IO, Set[AudioNode]],
+    private val mutedRef: Ref[IO, Boolean]
+)(using audioContext: AudioContext)
+    extends Instrument[ClickTrack.Settings]:
+
+  def mute: IO[Unit] = mutedRef.set(true)
+  def unmute: IO[Unit] = mutedRef.set(false)
+  def toggleMute: IO[Boolean] = mutedRef.modify(m => (!m, !m))
+  def isMuted: IO[Boolean] = mutedRef.get
+
+  private val clickDuration = 0.05
+
+  override protected def playWithSettings(
+      musicEvent: AtomicMusicalEvent,
+      when: Double,
+      tempo: Tempo,
+      settings: ClickTrack.Settings
+  )(using dom.AudioContext): IO[Unit] =
+    mutedRef.get.flatMap:
+      case true => IO.unit
+      case false =>
+        IO {
+          val osc = sineOscillator(when, clickDuration)
+            .withFrequency(AudioParam(Vector(SetValueAtTime(settings.frequency, when))))
+
+          val gain = Gain(
+            List.empty,
+            AudioParam(Vector(
+              SetValueAtTime(settings.volume, when),
+              ExponentialRampToValueAtTime(0.001, when + clickDuration)
+            )))
+
+          val graph = osc --> gain
+          graph.create.connect(audioContext.destination)
+        }
+end ClickTrack

--- a/js/src/main/scala/org/soundsofscala/instrument/ViolinSynth.scala
+++ b/js/src/main/scala/org/soundsofscala/instrument/ViolinSynth.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.instrument
 
 import cats.effect.{IO, Ref}

--- a/js/src/main/scala/org/soundsofscala/playback/FunctionalAudioPlayer.scala
+++ b/js/src/main/scala/org/soundsofscala/playback/FunctionalAudioPlayer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.playback
 
 import cats.effect.{IO, Ref}

--- a/js/src/main/scala/org/soundsofscala/playback/SimpleAudioPlayer.scala
+++ b/js/src/main/scala/org/soundsofscala/playback/SimpleAudioPlayer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.playback
 
 import cats.effect.IO

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong6.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.songexamples
 
 import cats.effect.IO

--- a/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong7SwingIt.scala
+++ b/js/src/main/scala/org/soundsofscala/songexamples/ExampleSong7SwingIt.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.soundsofscala.songexamples
 
 import cats.effect.IO

--- a/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
@@ -38,40 +38,69 @@ import scala.concurrent.duration.DurationDouble
  *   The time window in seconds in which to schedule notes ahead of time
  */
 
+private case class PlaybackLocation(
+    locatedEvent: MusicalEvent,
+    locatedBeatPosition: BeatPosition,
+    adjustedNoteTime: NextNoteTime)
+
 private case class ScheduleContext(
     trackIndex: TrackIndex,
     initialEvent: MusicalEvent,
     remainingEvent: MusicalEvent,
     nextNoteTime: NextNoteTime,
     beatPosition: BeatPosition,
-    swingCompensation: SwingOffset
+    startingBeatPosition: Option[BeatPosition],
+    swingCompensation: SwingOffset,
+    beatPositionOffset: Double = 0.0
 )
 
 final case class NoteScheduler(
     songRef: Ref[IO, Song],
+    beatPositionRef: Ref[IO, BeatPosition],
     lookAheadMs: LookAhead,
-    scheduleAheadTimeSeconds: ScheduleWindow):
+    scheduleAheadTimeSeconds: ScheduleWindow,
+    clickTrack: Track[?]):
 
-  def scheduleTrack(trackIndex: TrackIndex)(using ac: AudioContext): IO[Unit] =
-    def playCycle(nextNoteTime: NextNoteTime): IO[Unit] =
+  private def resolveTrack(trackIndex: TrackIndex, song: Song): Track[?] =
+    if trackIndex.value == 0 then clickTrack
+    else song.mixer.tracks.toList(trackIndex.value - 1)
+
+  def scheduleTrack(
+      trackIndex: TrackIndex,
+      startingBeatPosition: Option[BeatPosition] = None
+  )(using ac: AudioContext): IO[Unit] =
+    def playCycle(
+        nextNoteTime: NextNoteTime,
+        beatOffset: Double,
+        resumePosition: Option[BeatPosition]
+    ): IO[Unit] =
       for
         song <- songRef.get
-        track = song.mixer.tracks.toList(trackIndex.value)
+        track = resolveTrack(trackIndex, song)
+        patternLength = totalDurationInBeats(track.musicalEvent)
+        localResume = resumePosition.map(bp => BeatPosition(bp.value % patternLength))
+        adjustedOffset = resumePosition.fold(beatOffset)(bp =>
+          bp.value - (bp.value % patternLength))
         scheduleContext = ScheduleContext(
           trackIndex,
           initialEvent = track.musicalEvent,
           remainingEvent = track.musicalEvent,
           nextNoteTime,
           BeatPosition(0.0),
-          SwingOffset(0.0))
+          localResume,
+          SwingOffset(0.0),
+          beatPositionOffset = adjustedOffset
+        )
         finalNoteTime <- scheduleSequence(scheduleContext)
         _ <-
           track.playback match
-            case Playback.Loop => playCycle(finalNoteTime)
+            case Playback.Loop =>
+              playCycle(finalNoteTime, adjustedOffset + patternLength, resumePosition = None)
             case Playback.OneShot => IO.unit
       yield ()
 
-    playCycle(NextNoteTime(ac.currentTime))
+    playCycle(NextNoteTime(ac.currentTime), beatOffset = 0.0, resumePosition = startingBeatPosition)
+  end scheduleTrack
 
   private def scheduleSequence(context: ScheduleContext)(using AudioContext): IO[NextNoteTime] =
     ScheduleStatus.isReadyToSchedule(context.nextNoteTime, scheduleAheadTimeSeconds) match
@@ -80,7 +109,7 @@ final case class NoteScheduler(
       case ScheduleStatus.Ready =>
         // read latest version of the song
         songRef.get.flatMap: song =>
-          val track = song.mixer.tracks.toList(context.trackIndex.value)
+          val track = resolveTrack(context.trackIndex, song)
           val currentEventFromSongRef = track.musicalEvent
 
           // this compares the event from the song ref with the original event specified when the song started playing
@@ -91,32 +120,49 @@ final case class NoteScheduler(
 
   private def playNextNote(context: ScheduleContext, song: Song)(
       using AudioContext): IO[NextNoteTime] =
-    val track = song.mixer.tracks.toList(context.trackIndex.value)
+    val track = resolveTrack(context.trackIndex, song)
     val swingInMillis = calculateSwingOffset(song)
 
-    def calculateNextNoteTime(note: AtomicMusicalEvent, swingOffset: Double): NextNoteTime =
+    def calculateNextNoteTime(
+        baseTime: NextNoteTime,
+        note: AtomicMusicalEvent,
+        swingOffset: Double): NextNoteTime =
       NextNoteTime(
-        context.nextNoteTime.value + swingOffset + context.swingCompensation.value + note
+        baseTime.value + swingOffset + context.swingCompensation.value + note
           .durationToSeconds(song.tempo))
 
-    context.remainingEvent match
+    val playBackLocation = locatePlaybackPosition(context, song.tempo)
+    playBackLocation.locatedEvent match
       case sequence: Sequence =>
-        val updatedBeatPosition = incrementBeatPosition(context.beatPosition, sequence.head)
+        val updatedBeatPosition =
+          incrementBeatPosition(playBackLocation.locatedBeatPosition, sequence.head)
         val swingOffset =
           if updatedBeatPosition.isSwungBeat(song.swing) then swingInMillis else 0.0
-        val nextNextNoteTime = calculateNextNoteTime(sequence.head, swingOffset)
-        track.playAtomicMusicalEvent(sequence.head, context.nextNoteTime.value, song.tempo) >>
+        val nextNextNoteTime =
+          calculateNextNoteTime(playBackLocation.adjustedNoteTime, sequence.head, swingOffset)
+        IO.whenA(context.trackIndex.value == 0)(beatPositionRef.set(
+          BeatPosition(updatedBeatPosition.value + context.beatPositionOffset))) >>
+          track.playAtomicMusicalEvent(
+            sequence.head,
+            playBackLocation.adjustedNoteTime.value,
+            song.tempo) >>
           scheduleSequence(context.copy(
             remainingEvent = sequence.tail,
             nextNoteTime = nextNextNoteTime,
             beatPosition = updatedBeatPosition,
-            swingCompensation = SwingOffset.compensation(swingOffset)))
+            startingBeatPosition = None,
+            swingCompensation = SwingOffset.compensation(swingOffset)
+          ))
       case atomicEvent: AtomicMusicalEvent =>
-        val nextNextNoteTime = calculateNextNoteTime(atomicEvent, swingOffset = 0.0)
-        track.playAtomicMusicalEvent(atomicEvent, context.nextNoteTime.value, song.tempo)
-          // at the very end of the sequence we return the time of the final note so we can
-          // use this for Playback.Loop
-          .as(nextNextNoteTime)
+        val updatedBeatPosition =
+          incrementBeatPosition(playBackLocation.locatedBeatPosition, atomicEvent)
+        val nextNextNoteTime =
+          calculateNextNoteTime(playBackLocation.adjustedNoteTime, atomicEvent, swingOffset = 0.0)
+        IO.whenA(context.trackIndex.value == 0)(beatPositionRef.set(
+          BeatPosition(updatedBeatPosition.value + context.beatPositionOffset))) >>
+          track.playAtomicMusicalEvent(atomicEvent, context.nextNoteTime.value, song.tempo)
+            .as(nextNextNoteTime)
+    end match
   end playNextNote
 
   private def applyLiveUpdate(
@@ -142,10 +188,25 @@ final case class NoteScheduler(
       beatPosition = currentBeatPosition
     ))
 
+  private def locatePlaybackPosition(
+      context: ScheduleContext,
+      tempo: Tempo): PlaybackLocation =
+    context.startingBeatPosition.fold(
+      PlaybackLocation(context.remainingEvent, context.beatPosition, context.nextNoteTime)
+    ) { target =>
+      val (event, beatPos) = findEventAtBeatPosition(context.remainingEvent, target)
+      val adjustedNoteTime = adjustNoteTimeForBeatOffset(
+        context.nextNoteTime,
+        target,
+        beatPos,
+        tempo)
+      PlaybackLocation(event, beatPos, adjustedNoteTime)
+    }
+
   /*
   Compensating - Event Boundary
 
-  A Mismatch happens when two tracks have different subdivision patterns
+  A mismatch happens when two tracks have different subdivision patterns
   I found this with the hi-hats being 8ths and kick being quarter notes
 
   Say you resume or create a live update at beat 3.5
@@ -172,6 +233,7 @@ final case class NoteScheduler(
   beats to seconds using the tempo, and shifts noteTime forward by that amount.
   So the note plays at the correct AudioContext time for the beat it's actually at.
    */
+
   private def adjustNoteTimeForBeatOffset(
       noteTime: NextNoteTime,
       expectedBeatPosition: BeatPosition,
@@ -211,6 +273,13 @@ final case class NoteScheduler(
     // start from the beginning and find event at targetBeatPosition
     loop(event, BeatPosition(0.0))
 
+  @tailrec
+  private def totalDurationInBeats(event: MusicalEvent, acc: Double = 0.0): Double =
+    event match
+      case sequence: Sequence =>
+        totalDurationInBeats(sequence.tail, acc + sequence.head.durationToBeats)
+      case atomic: AtomicMusicalEvent => acc + atomic.durationToBeats
+
   private def calculateSwingOffset(song: Song): Double =
     val swingFromTempo = song.swing.amount.value.toDouble / 1000.0 * (60.0 / song.tempo.value)
     song.swing.resolution match
@@ -219,8 +288,11 @@ final case class NoteScheduler(
 
   private def incrementBeatPosition(
       currentBeatPosition: BeatPosition,
-      note: AtomicMusicalEvent): BeatPosition =
-    val durationInBeats = note.durationToBeats
+      sequence: MusicalEvent): BeatPosition =
+    val durationInBeats = sequence match
+      case Sequence(head, tail) => head.durationToBeats
+      case e: AtomicMusicalEvent => e.durationToBeats
+
     BeatPosition(currentBeatPosition.value + durationInBeats)
 
   extension (beatPosition: BeatPosition)

--- a/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
@@ -21,10 +21,8 @@ import cats.effect.Ref
 import cats.effect.kernel.Fiber
 import cats.syntax.all.*
 import org.scalajs.dom.AudioContext
-import org.soundsofscala.models.LookAhead
-import org.soundsofscala.models.ScheduleWindow
-import org.soundsofscala.models.Song
-import org.soundsofscala.models.TrackIndex
+import org.soundsofscala.instrument.ClickTrack
+import org.soundsofscala.models.*
 
 /**
  * The sequencer is responsible for scheduling the notes of every track in the song in parallel. It
@@ -35,21 +33,34 @@ import org.soundsofscala.models.TrackIndex
  *
  * @param songRef
  *   A Ref holding the current Song, enabling live updates to any property
+ * @param beatPositionRef
+ *   A Ref containing the current beat position while playing
+ * @param pausedAtRef
+ *   A Ref holding beat position of song when paused
  */
 
 class Sequencer private (
     val songRef: Ref[IO, Song],
-    private val fiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]]
+    private val fiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+    private val beatPositionRef: Ref[IO, BeatPosition],
+    private val pausedAtRef: Ref[IO, Option[BeatPosition]],
+    val clickTrack: ClickTrack
 )(using audioContext: AudioContext):
 
   def updateSong(f: Song => Song): IO[Unit] = songRef.update(f)
 
+  def currentBeatPosition: IO[BeatPosition] = beatPositionRef.get
+
+  def toggleClick: IO[Boolean] = clickTrack.toggleMute
+
   def play(): IO[Unit] =
     for
       song <- songRef.get
-      _ <- IO.println(s"Playing: ${song.title}")
+      pausedAt <- pausedAtRef.get
+      _ <- IO.println(pausedAt.fold(s"Playing: ${song.title}")(bp =>
+        s"Resuming: ${song.title} from beat ${bp.value}"))
       _ <- stop()
-      fiber <- startPlayback().start
+      fiber <- startPlaybackFromBeat(pausedAt).start
       _ <- fiberRef.set(fiber.some)
     yield ()
 
@@ -58,26 +69,53 @@ class Sequencer private (
       case Some(fiber) =>
         IO.println("Stopping sequencer") *>
           fiber.cancel *>
-          stopInstruments()
+          stopInstruments() *>
+          beatPositionRef.set(BeatPosition(0.0)) *>
+          pausedAtRef.set(none)
       case none => IO.unit
 
-  private def stopInstruments(): IO[Unit] =
-    songRef.get.flatMap(_.mixer.tracks.parTraverse(_.instrument.stop.void).void)
+  def pause(): IO[Unit] =
+    for
+      _ <- fiberRef.getAndSet(none).flatMap {
+        case Some(fiber) =>
+          fiber.cancel *>
+            stopInstruments()
+        case none => IO.unit
+      }
+      beatPosition <- beatPositionRef.get
+      _ <- pausedAtRef.set(beatPosition.some)
+      _ <- IO.println(s"Paused at beat: ${beatPosition.value}")
+    yield ()
 
-  private def startPlayback(): IO[Unit] =
-    songRef.get.flatMap: song =>
-      val noteScheduler = NoteScheduler(songRef, LookAhead(25), ScheduleWindow(0.1))
-      /* create indexes for each track so the scheduler can re-read the track from the
-      songRef on every note — this enables live updates */
-      song.mixer.tracks.zipWithIndex.parTraverse: (_, index) =>
-        noteScheduler.scheduleTrack(TrackIndex(index))
-      .void *>
-        songRef.get.flatMap(s => IO.println(s"Finished playing: ${s.title}"))
+  private def stopInstruments(): IO[Unit] =
+    clickTrack.stop.void *>
+      songRef.get.flatMap(_.mixer.tracks.parTraverse(_.instrument.stop.void).void)
+
+  private def startPlaybackFromBeat(positionToStartAt: Option[BeatPosition]): IO[Unit] =
+    positionToStartAt.fold(IO.unit)(beatPositionRef.set) >>
+      songRef.get.flatMap: song =>
+        val noteScheduler =
+          NoteScheduler(
+            songRef,
+            beatPositionRef,
+            LookAhead(25),
+            ScheduleWindow(0.1),
+            ClickTrack.track(clickTrack))
+
+        val scheduleClick = noteScheduler.scheduleTrack(TrackIndex(0), positionToStartAt)
+        val scheduleSongTracks = (1 to song.mixer.tracks.size).toList.parTraverse: index =>
+          noteScheduler.scheduleTrack(TrackIndex(index), positionToStartAt)
+
+        // We use IO.race to stop the click track when the song finishes
+        IO.race(scheduleSongTracks.void, scheduleClick).void *>
+          songRef.get.flatMap(song => IO.println(s"Finished playing: ${song.title}"))
 end Sequencer
 
 object Sequencer:
   def apply(songRef: Ref[IO, Song])(using AudioContext): IO[Sequencer] =
-    Ref.of[IO, Option[Fiber[IO, Throwable, Unit]]](none).map: fiberRef =>
-      new Sequencer(songRef, fiberRef)
-
-end Sequencer
+    for
+      fiberRef <- Ref.of[IO, Option[Fiber[IO, Throwable, Unit]]](none)
+      beatPositionRef <- Ref.of[IO, BeatPosition](BeatPosition(0.0))
+      pausedAtRef <- Ref.of[IO, Option[BeatPosition]](None)
+      clickTrack <- ClickTrack()
+    yield new Sequencer(songRef, fiberRef, beatPositionRef, pausedAtRef, clickTrack)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.0
+sbt.version = 1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,13 @@
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+resolvers += Resolver.sonatypeCentralSnapshots
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-scalafix" % "0.7.7")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % "0.7.7")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.7.7")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.7.7")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
-libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
+addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % "0.8.6")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.8.6")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.8.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1"


### PR DESCRIPTION
### Sequencer features
- **Pause & resume** — Sequencer now supports pausing playback and resuming from the paused beat position, with correct timing alignment across tracks with different subdivisions
- **Beat position tracking** — Exposed `currentBeatPosition` via a `Ref` so the UI can poll and display the current beat
- **Click track** — Added a new `ClickTrack` instrument that plays alongside the song tracks, with a `toggleClick` mute/unmute control. Uses `IO.race` to automatically cancel the click when song tracks finish
- **Resume-aware scheduling** — NoteScheduler now accepts a starting beat position, locates the correct event at that position, and adjusts note timing to keep tracks in sync when resuming mid-pattern

### UI / Main.scala
- **Beat position display** — Polling loop that updates a DOM element with the current beat every 100ms
- **Swing controls** — Realtime swing up/down buttons and click track toggle for ExampleSong1
- **Kick pattern toggle** — Realtime swap between original and double kick patterns
- **Refactored for comprehension** — Extracted button action logic into private methods (`song1PlayAction`, `song1StopAction`, `song1PauseAction`, `song1ExtraActions`, `toggleKickAction`, `swingExtraActions`)

### Build & tooling
- **Scala 3.8.2 → 3.8.4**
- **sbt 1.10.0 → 1.12.11**
- **sbt-typelevel 0.7.7 → 0.8.6** (with `sbt-typelevel-scalafix` replaced by standalone `sbt-scalafix`)
- **sbt-scalajs 1.20.1 → 1.21.0**, scalafmt, scalajs-crossproject, and other plugin bumps
- **Fixed deprecated Sonatype resolver** — `sonatypeOssRepos` → `sonatypeCentralSnapshots`
- **Added sbt-header 5.10.0** — Restores `headerCreate` task (was bundled with sbt-typelevel 0.7.x but dropped in 0.8.x)
- **License headers added** to new files
- **Added new contributor** — Sabrina Konrad-lee
- **Docs version bump** — README updated to 0.8.1
