### PR TITLE
SOS-0000: Increase resoluton of currentBeatPosition to 16th-note reso…

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,7 +14,6 @@ indent.matchSite = 2
 newlines.source = keep
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
-rewrite.scala3.insertEndMarkerMinLines = 30
 
 includeCurlyBraceInSelectChains = true
 includeNoParensInSelectChains = true

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 ## A Web Music & Audio library for Scala
 
+A living, breathing example application can be found at [www.virtualmattondrums.com](https://www.virtualmattondrums.com)
+
+For Documentation and Examples see: [Sounds of Scala](https://pauliamgiant.github.io/sounds-of-scala/)
+
 The fastest way to make some sound emanate from your device is with the SimpleAudioPlayer.
 
 Add the following to your build.sbt file:
 
-For Documentation and Examples see: [Sounds of Scala](https://pauliamgiant.github.io/sounds-of-scala/)
-
 ```scala 3
-libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.7.0"
+libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.8.2"
 ```
 Then in the code of your Scala.js project pass the path to an audio file to the SimpleAudioPlayer constructor.
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,13 +74,13 @@ lazy val sos = crossProject(JSPlatform, JVMPlatform)
     mimaPreviousArtifacts := Set.empty,
     moduleName := "sounds-of-scala",
     libraryDependencies ++= Seq(
-      "org.scalactic" %%% "scalactic" % "3.2.20",
-      "org.scalatest" %%% "scalatest" % "3.2.20" % Test,
       "org.typelevel" %%% "cats-core" % "2.13.0",
       "org.typelevel" %%% "cats-effect" % "3.7.0",
       "io.kevinlee" %%% "refined4s-core" % "1.16.0",
-      "io.kevinlee" %%% "refined4s-cats" % "1.16.0"
-    )
+      "io.kevinlee" %%% "refined4s-cats" % "1.16.0",
+      "com.disneystreaming" %%% "weaver-cats" % "0.8.4" % Test,
+    ),
+    testFrameworks += new TestFramework("weaver.framework.CatsEffect")
   )
   .jvmSettings(
     libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided"

--- a/docs/src/pages/README.md
+++ b/docs/src/pages/README.md
@@ -1,14 +1,17 @@
 # Sounds of Scala
 
-Sounds of Scala is a Music and Audio Lib for Scala.js. It is designed to be a simple and easy to use library for creating music and audio Web Applications using Scala.
+Sounds of Scala is an Audio and Music library for Scala 3 and Scala.js. 
+We had rthe intention of making it a simple and easy to use library for creating music and audio Web Applications using Scala. We're getting there on that.
+
+In the meantime, a living, breathing example application built with Sounds of Scala can be found at [www.virtualmattondrums.com](https://www.virtualmattondrums.com)
 
 ## Dependencies
 
-Sounds of Scala is available for Scala 3.2+. You can add Sounds of Scala to your build by adding its modules to `libraryDependencies` in your `build.sbt`.
+Sounds of Scala is available for Scala 3.8.4+. You can add Sounds of Scala to your build by adding its modules to `libraryDependencies` in your `build.sbt`.
 
 ```scala 3
 libraryDependencies ++= Seq(
-  "org.soundsofscala" %%% "sounds-of-scala" % "0.8.1")
+  "org.soundsofscala" %%% "sounds-of-scala" % "0.8.2")
 ```
 
-### [Next Step: Getting Started](http://127.0.0.1:4242/getting-started/)
+### [Next Step: Getting Started](getting-started/README.md)

--- a/docs/src/pages/getting-started/README.md
+++ b/docs/src/pages/getting-started/README.md
@@ -1,52 +1,101 @@
 # Getting Started
 
+## Adding Sounds of Scala to your project
+
+Add the following to your build.sbt file:
+
+```scala 3
+libraryDependencies += "org.soundsofscala" %%% "sounds-of-scala" % "0.8.2"
+```
+
+## Playing Audio
+
+It occurred to me two years into the project that the most basic functionality to provide is to simply be able to play audio from a Scala project.
+
+The fastest way to make some sound emanate from your device is with the SimpleAudioPlayer.
+
+In the code of your Scala.js project, pass the path to an audio file to the SimpleAudioPlayer constructor.
+
+Making sure you have the volume turned up is on you.
+
+```scala 3
+val audioPlayer = SimpleAudioPlayer("<PATH_TO_LOCAL_AUDIO_FILE>")
+audioPlayer.play()
+audioPlayer.pause()
+audioPlayer.play()
+audioPlayer.stop()
+```
+
 ## Creating a Scala.js Project
 
-In order to use Sounds of Scala you will need to create a Scala.js project.
+In order to use Sounds of Scala to build a web audio application you will need to create a Scala.js project.
 
-There are a number of ways to create a Scala.js project for use with Sounds of Scala. At some point you can expect to find a giter8 template here which will do this all for you but for now you can use one of the following methods. 
+There are a number of ways to create a Scala.js project. At some point you can expect to find a giter8 template here which will do this all for you but for now you can use one of the following methods.
+
+---
+
+### Scala.js with Tyrian (Recommended)
+
+[Tyrian](https://tyrian.indigoengine.io/) is a Scala.js web framework built on Cats Effect. Since Sounds of Scala also uses Cats Effect for all of its IO and concurrency, Tyrian is the natural pairing. You get a consistent functional programming model across your UI and audio code, with no need to bridge between different effect systems.
+
+```bash
+sbt new PurpleKingdomGames/tyrian.g8
+```
+
+---
+
+### Scala.js with Laminar
+
+[Laminar](https://laminar.dev/) is another excellent Scala.js UI framework. It uses its own reactive system (Airstream) rather than Cats Effect, so you will need to bridge between the two when connecting your UI to the Sounds of Scala API.
+
+```bash
+sbt new raquo/scalajs.g8
+```
+
+Say "yes" to Laminar and CSS.
 
 ---
 
 ### Scala.js with Vite
+
+If you prefer a minimal setup without a UI framework, you can use the Scala.js Vite template.
+
 ```bash
 sbt new scala-js/vite.g8
 ```
-Once you have the created the project from the giter8 template bump the minimum versions of the following:
+
+Once you have created the project from the giter8 template, bump the minimum versions of the following:
 
 In project/build.properties:
+
 ```bash
 sbt.version=1.10.0
 ```
-In build.sbt
+
+In build.sbt:
+
 ```scala 3
  scalaVersion := "3.3.3"
  "org.scala-js" %%% "scalajs-dom" % "2.8.0"
 ```
-And in project/plugins.sbt the sbt-scalajs plug in.
+
+And in project/plugins.sbt:
+
 ```scala 3
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-
 ```
 
-
-
----
-
-### Scala.js with Tyrian
-```bash
-sbt new PurpleKingdomGames/tyrian.g8
-``` 
 ---
 
 ### Scala.js docs
+
 [Scala.js Docs](https://www.scala-js.org/doc/tutorial/basic/)
-And then follow this guide to add Scala
 
 ### A Quick Project Scaffold using Scala.js & Vite
-Here is an example of a simple Scala.js project using the Vite template:
 
-You can use this to get started with your own project quickly, and simply start using the Sounds of Scala library from within the **firstMusicProgram** method.
+Here is an example of a simple Scala.js project using the Vite template.
+
+You can use this to get started quickly and start using the Sounds of Scala library from within the **firstMusicProgram** method.
 
 ```scala 3
 import cats.effect.{IO, Ref}
@@ -64,6 +113,7 @@ def helloWorld(): Unit =
   val heading = document.createElement("h1")
   heading.textContent = "My First Music App"
 
+// asInstanceOf - you'll have to get over it on this occasion
   val button = document.createElement("button").asInstanceOf[dom.html.Button]
   button.classList.add("button")
   button.textContent = "▶️"
@@ -76,7 +126,8 @@ def helloWorld(): Unit =
   dom.document.querySelector("#app").append(homeDiv)
 
 def firstMusicProgram(): AudioContext ?=> IO[Unit] = ???
-  
+
   // TODO: Your code
 ```
+
 ### [Next Step: Playing a test song](../getting-started/playing-test-song.md)

--- a/docs/src/pages/getting-started/playing-test-song.md
+++ b/docs/src/pages/getting-started/playing-test-song.md
@@ -36,7 +36,13 @@ def firstMusicProgram(): AudioContext ?=> IO[Unit] =
   yield ()
 ```
 
-The `Song` is pure data — it holds the title, tempo, swing and mixer (tracks). To play it, we wrap it in a `Ref[IO, Song]` and pass it to a `Sequencer`. The Ref enables real-time updates to any property while the song is playing.
+The `Song` is pure data. It holds the title, tempo, swing and mixer (tracks). To play it, we wrap it in a `Ref[IO, Song]` and pass it to a `Sequencer`.
+
+#### Why a Ref?
+
+The Sequencer re-reads the `Song` from the `Ref` before scheduling every note. This means any change you make to the `Song` (tempo, swing, or even swapping out an entire track's pattern) takes effect immediately during playback. Without the `Ref`, the Sequencer would have a static snapshot of the song with no way to react to changes.
+
+This is also what enables pause and resume. The Sequencer tracks the current beat position as it plays, so when you call `sequencer.pause()` it preserves where you are in the song, and `sequencer.play()` picks up from that position.
 
 Once you have played that and heard some audio playing you can:
 - Click into `ExampleSong1` and see how the song is defined

--- a/docs/src/pages/instruments/PianoSynth.md
+++ b/docs/src/pages/instruments/PianoSynth.md
@@ -1,7 +1,41 @@
 ### PianoSynth
 
-This is a basic fundamental electronic Piano instrument.
 
-We're confident one day it will sound more like an electronic piano.. until then it works in that role.
+The PianoSynth is a synthesised keyboard instrument built using the Web Audio API's wavetable oscillator. It generates its tone from a custom Fourier series with six harmonics, giving it a bright, clear timbre. A velocity sensitive envelope shapes each note with a fast attack, a gentle decay, and a long exponential release.
 
-### [Next Step: Sampler](../instruments/Sampler.md)
+We're confident one day it will sound more like an electronic piano.. until then it can limp along in this role.
+
+#### Creating a PianoSynth
+
+The PianoSynth is created as an `IO` since it initialises internal state for tracking active audio nodes.
+
+```scala 3
+val piano: IO[PianoSynth] = PianoSynth()
+```
+
+#### Using in a Song
+
+A single PianoSynth instance can be shared across multiple tracks. Here is an example from the Beethoven song included with the library:
+
+```scala 3
+PianoSynth().map: sharedPiano =>
+  Song(
+    title = Title("Something We All Know"),
+    tempo = Tempo(110),
+    mixer = Mixer(
+      Track(
+        Title("Upper Voice"),
+        upperVoice,
+        sharedPiano,
+        Playback.OneShot),
+      Track(
+        Title("Lower Voice"),
+        lowerVoice,
+        sharedPiano,
+        Playback.OneShot)
+    ))
+```
+
+
+
+### [Next Step: ScalaSynth](../instruments/ScalaSynth.md)

--- a/docs/src/pages/instruments/README.md
+++ b/docs/src/pages/instruments/README.md
@@ -1,9 +1,28 @@
 # Instruments
 
-Examples of virtual instruments are Synthesizers, Sequencers, Drum Machines, and Samplers.
+Every track in a song needs an instrument to produce sound. All instruments implement the `Instrument` trait, which provides `play` and `stop` methods. The library ships with synthesizers, drum machines and a sampler.
 
-There are a handful of non-configurable basic instruments provided by the library at this time.
+#### Sampler
 
-### [Next Step: ScalaSynth](../instruments/ScalaSynth.md)
+The **Sampler** is one of the most powerful instruments in the library. It lets you load real audio samples and play them back at any pitch by automatically adjusting the playback rate. It uses a binary search to find the closest sample to the target frequency, keeping pitch shifting artefacts to a minimum.
+
+The library ships with several built in sample sets ready to use: `Sampler.piano`, `Sampler.guitar`, `Sampler.bassGuitar`, `Sampler.kickDrum`, `Sampler.snareDrum` and a few more unusual ones. You can also load your own samples from any audio file path using `Sampler.fromPaths`.
+
+#### Synthesizers
+
+Synths generate sound from oscillators and are used for melodic content (notes, chords, melodies). Each synth uses a different waveform or synthesis technique to produce its timbre:
+
+- **ScalaSynth** - The default synth, a simple starting point
+- **PianoSynth** - Wavetable oscillator with a velocity sensitive envelope. There is a built in Piano sampler however that uses real samples so if you actually want to play a piano you should use that instead.
+- **ViolinSynth** - Wavetable oscillator with vibrato and filtering to approximate a bowed string
+- **QuirkyFilterSynth** - An experimental synth with filter modulation for more unusual timbres. If anybody calls you quirky it will surely be a compliment.
+
+All synths extend the `Synth` trait, which handles note and chord playback. You can call `Synth()` to get the default (ScalaSynth).
+
+#### Drum Machines
+
+- **Simple80sDrumMachine** - A digital drum synthesiser modelled on vintage 80s electronic drum machines with Kick, Snare and HiHat voices
+
+### [Next Step: Sampler](../instruments/Sampler.md)
 
 

--- a/docs/src/pages/instruments/Sampler.md
+++ b/docs/src/pages/instruments/Sampler.md
@@ -1,3 +1,47 @@
-### Sampler - COMING SOON
+### Sampler
 
+This Sampler was built as a Scala Centre Google summer of code project in 2024 by Johanna Odersky. It acts like a classic hardward sampler in a traditional sense, allowing you to load real audio samples and play them back as part of a song at any pitch.
 
+Here is a link to [Johanna's project write up](https://gist.github.com/ikukojohanna/5e23c4bd79e24c2aeb8454b2507981d1).
+
+When a note is played, it finds the closest sample to the target frequency using a binary search and adjusts the playback rate to match the requested pitch. This keeps pitch shifting artefacts to a minimum by always playing from the nearest available sample.
+
+#### Built in Sample Sets
+
+The library ships with several ready to use sample sets:
+
+```scala 3
+Sampler.piano        // Piano samples across 2 octaves
+Sampler.guitar       // Acoustic guitar samples played by Harvey Cambridge potentially in his bedroom.
+Sampler.bassGuitar   // Pauls musicman stingray bass guitar samples across 2 octaves
+Sampler.kickDrum     // Doob, Doob
+Sampler.snareDrum    // Snare drum
+Sampler.rhubarb      // Yup, rhubarb
+Sampler.vinyl        // Vinyl noise
+Sampler.sparkles     // Sparkle effect
+```
+
+#### Loading your own Samples
+
+You can create a Sampler from any audio files by providing a list of `SampleKey` to file path pairs. Each `SampleKey` identifies the pitch of the sample so the Sampler knows how to pitch shift from it.
+
+```scala 3
+val mySampler: IO[Sampler] = Sampler.fromPaths(List(
+  SampleKey(Pitch.C, Accidental.Natural, Octave(3)) -> "path/to/c3.wav",
+  SampleKey(Pitch.G, Accidental.Natural, Octave(3)) -> "path/to/g3.wav"
+))
+```
+
+The more samples you provide across the pitch range, the less pitch shifting is needed and the more natural the result will sound.
+
+The best examples of how to use the Sampler can be found in the `Sampler` companion object itself. Each built in sample set (such as `Sampler.piano` or `Sampler.bassGuitar`) demonstrates the pattern: define a list of `SampleKey` to file path pairs, then call `Sampler.fromPaths`. The companion object source is at `org.soundsofscala.instrument.Sampler`.
+
+#### Example Songs using the Sampler
+
+`ExampleSong1` is a full multi track song that mixes samplers with synths. It creates a custom drum sampler from individual kick, snare and hihat audio files, loads the built in `Sampler.bassGuitar` and `Sampler.guitar`, and combines them with `ScalaSynth` and `QuirkyFilterSynth` tracks. It is a good reference for how to wire up custom `SamplePlayer.Settings` per track.
+
+`ExampleSongSampler` showcases the more unusual built in sample sets like `Sampler.rhubarb`, `Sampler.vinyl` and `Sampler.sparkles`. It also demonstrates reversed playback using custom `SamplePlayer.Settings` with `reversed = true`, along with offset and length controls for slicing into a sample.
+
+Both can be found in the `org.soundsofscala.songexamples` package.
+
+### [Next Step: PianoSynth](../instruments/PianoSynth.md)

--- a/docs/src/pages/instruments/SawtoothSynth.md
+++ b/docs/src/pages/instruments/SawtoothSynth.md
@@ -1,5 +1,0 @@
-### SawtoothSynth
-
-The `SawtoothSynth` is another singe oscillator synthesizer built from a sawtooth wave. 
-
-### [Next Step: SimpleDrumMachine](../instruments/SimpleDrumMachine.md)

--- a/docs/src/pages/instruments/ScalaSynth.md
+++ b/docs/src/pages/instruments/ScalaSynth.md
@@ -4,4 +4,4 @@ This is a basic fundamental Synthesiser instrument.
 
 If you think at sounds average, youre not alone and you can expect this to evolve somewhat until I'm happy with it.
 
-### [Next Step: SineSynth](../instruments/SineSynth.md)
+### [Next Step: Simple80sDrumMachine](../instruments/Simple80sDrumMachine.md)

--- a/docs/src/pages/instruments/Simple80sDrumMachine.md
+++ b/docs/src/pages/instruments/Simple80sDrumMachine.md
@@ -1,0 +1,5 @@
+### Simple80sDrumMachine
+
+This is a very simple digital drum synthesiser modelled on vintage 80's electronic drum machines.
+
+It has only 3 voices at present: Kick, Snare and HiHat. Each voice has a single sound with volume controlled by a simple envelope that is set from the note velocity of a musical event.

--- a/docs/src/pages/instruments/SimpleDrumMachine.md
+++ b/docs/src/pages/instruments/SimpleDrumMachine.md
@@ -1,7 +1,0 @@
-### SimpleDrumMachine
-
-This is a very simple digital drum synthesiser modelled on vintage 80's electronic drum machines. 
-
-It has only 3 voices at present: Kick, Snare and HiHat. Each voice has a single sound with volume controlled by a simple envelope that is set from the note velocity of a musical event. 
-
-### [Next Step: PianoSynth](../instruments/PianoSynth.md)

--- a/docs/src/pages/instruments/SineSynth.md
+++ b/docs/src/pages/instruments/SineSynth.md
@@ -1,5 +1,0 @@
-### SineSynth
-
-The `SineSynth` is a the simplest form of synthesizer that generates a sine wave. 
-
-### [Next Step: SawtoothSynth](../instruments/SawtoothSynth.md)

--- a/docs/src/pages/instruments/directory.conf
+++ b/docs/src/pages/instruments/directory.conf
@@ -1,11 +1,7 @@
 laika.navigationOrder = [
   README.md
-  ScalaSynth.md
-  SineSynth.md
-  SawtoothSynth.md
-  SimpleDrumMachine.md
-  PianoSynth.md
   Sampler.md
-
-  
+  PianoSynth.md
+  ScalaSynth.md
+  Simple80sDrumMachine.md
 ]

--- a/docs/src/pages/music-dsl/building-melodies.md
+++ b/docs/src/pages/music-dsl/building-melodies.md
@@ -9,6 +9,6 @@ Melodies are a sequence of notes. They can be defined using the Sequence class. 
     F3 + F3 + E3 + E3 + D3 + D3 + C3.half
 ```
 
-To listen to this you can import ExampleSong0 from the `sounds-of-scala` library and play it.
+To listen to this you can import `ExampleSong1` from the `sounds-of-scala` library and play it.
 
 ### [Next Step: Syntax](../music-dsl/syntax.md)

--- a/docs/src/pages/music-dsl/building-notes.md
+++ b/docs/src/pages/music-dsl/building-notes.md
@@ -4,7 +4,7 @@ Notes are the building blocks of music. They are defined by their pitch, acciden
 
 Here is the Note Model
 ```scala 3
-enum AtomoicMusicalEvent:
+enum AtomicMusicalEvent:
   case Note(
     pitch: Pitch,
     accidental: Accidental,
@@ -18,13 +18,13 @@ enum AtomoicMusicalEvent:
 - **pitch**: The pitch of the note (A, B, C, D, E, F, G)
 - **accidental**: The accidental of the note (Natural, Sharp, Flat)
 - **duration**: The duration of the note (Whole, Half, Quarter, Eighth, Sixteenth, ThirtySecond)
-- **octave**: The octave of the note (Octave1, Octave2, Octave3, Octave4, Octave5, Octave6, Octave7)
-- **velocity**: The velocity of the note (Soft, Medium, Loud) or (pp, p, mp, mf, f, ff)
-- **offset**: The timing offset of the note to gain further fine grained control of the timing of the note (yet to be implemented)
+- **octave**: The octave of the note, a refined `Int` constructed as `Octave(n)` where n is typically 0 to 8
+- **velocity**: The velocity of the note. Plain English names: `Softest`, `Soft`, `Medium`, `Assertively`, `Loud`, `Louder`, `OnFull`. Musical dynamics: `Pianississimo`, `Pianissimo`, `Piano`, `MezzoPiano`, `MezzoForte`, `Forte`, `Fortissimo`, `Fortississimo`. Shorthand methods are also available on notes: `.ppp`, `.pp`, `.p`, `.mp`, `.mf`, `.f`, `.ff`, `.fff`
+- **offset**: The timing offset of the note for fine grained control of timing
 
 Here is an example of defining a single note:
 ```scala 3
-Note(C, Natural, Quarter, Octave4, Medium)
+Note(C, Natural, Quarter, Octave(4), Medium)
 ```
 
 ### Idiomatic Notes

--- a/docs/src/pages/music-dsl/musical-events.md
+++ b/docs/src/pages/music-dsl/musical-events.md
@@ -6,9 +6,11 @@ There are two main subtypes of `MusicalEvent`:
 - `Sequence` - a sequence of events that can be played in order
 
 ```scala 3
-sealed trait MusicalEvent:
-    enum AtomicMusicalEvent(duration: Duration, velocity: Velocity) extends MusicalEvent
-    final case class Sequence(head: AtomicMusicalEvent, tail: MusicalEvent) extends MusicalEvent
+sealed trait MusicalEvent
+
+enum AtomicMusicalEvent(duration: Duration, velocity: Velocity) extends MusicalEvent
+
+final case class Sequence(head: AtomicMusicalEvent, tail: MusicalEvent) extends MusicalEvent
 ```
 
 

--- a/docs/src/pages/music-dsl/quick-song.md
+++ b/docs/src/pages/music-dsl/quick-song.md
@@ -23,7 +23,7 @@ def writingAFirstSong(): AudioContext ?=> IO[Song] =
   yield Song(
     title = Title("First, Maybe Last Song"),
     tempo = Tempo(120),
-    swing = Swing(0),
+    swing = Swing(SwingAmount(0), SwingResolution.Eighth),
     mixer = Mixer(
       Track(
         title = Title("Scala Synth Bassline"),

--- a/docs/src/pages/music-dsl/songs.md
+++ b/docs/src/pages/music-dsl/songs.md
@@ -6,13 +6,13 @@ The Song type is the top level data structure containing all elements required t
 case class Song(
     title: Title,
     tempo: Tempo = Tempo(120),
-    swing: Swing = Swing(0),
+    swing: Swing = Swing(SwingAmount(0), SwingResolution.Eighth),
     mixer: Mixer
 )
 ```
 The title, tempo and swing, should be self explanatory and take provided types wrapping a string and integers for these values.
 
-> NOTE: Swing is yet to be implemented.
+`Swing` takes a `SwingAmount` (a refined `Int`) and a `SwingResolution` (`Eighth` or `Sixteenth`) that controls which beats get the swing feel.
 
 ### The Mixer Type
 
@@ -44,7 +44,7 @@ case class Track[Settings](
     playback: Playback,
     customSettings: Option[Settings] = None,
     insertFX: List[FX] = List.empty,
-    sendFX: List[FX] = List.empty)
+    sendFX: List[FX] = List.empty)(using Default[Settings])
 ```
 
 ### Playing a Song with the Sequencer

--- a/docs/src/pages/music-dsl/syntax.md
+++ b/docs/src/pages/music-dsl/syntax.md
@@ -1,8 +1,6 @@
-# MusicalEvent Syntax 
-
+# MusicalEvent Syntax
 
 Below are some examples of the syntax provided by the `sounds-of-scala` library for generating MusicalEvents. This syntax is designed to make it easier to define notes, chords, and drum strokes.
-
 
 ### Quick Notes
 
@@ -21,9 +19,10 @@ Quick notes are defined for convenience. These can be used to quickly define com
 ### Defining Accidental, Velocity, and Duration
 
 Chaining properties onto a note using smart constructors. The below will produce a note with the properties:
-- Pitch: G1 sharp 
+
+- Pitch: G1 sharp
 - Duration: A sixteenth or semi-quaver
-- Velocity: Medium  
+- Velocity: Medium
 
 ```scala 3
 G3.sharp.sixteenth.medium
@@ -81,6 +80,7 @@ kk.whole.assertively
 ```
 
 ### Quick Rests
+
 ```scala 3
     val RestWhole = Rest(Whole)
     val RestHalf = Rest(Half)
@@ -107,4 +107,4 @@ kk.whole.assertively
     val r32triplet = Rest(ThirtySecondTriplet)
 ```
 
-### [Next Step: Syntax](../instruments/README.md)
+### [Next Step: Instruments](../instruments/README.md)

--- a/js/src/main/scala/org/soundsofscala/Main.scala
+++ b/js/src/main/scala/org/soundsofscala/Main.scala
@@ -223,7 +223,7 @@ object Main extends IOApp:
       (
         "🕰️",
         "swing-button",
-        sequencer.toggleClick.flatMap(muted =>
+        sequencer.toggleClickOnOff.flatMap(muted =>
           IO.println(s"Click track: ${if muted then "off" else "on"}")))
     )
 

--- a/js/src/main/scala/org/soundsofscala/instrument/ClickTrack.scala
+++ b/js/src/main/scala/org/soundsofscala/instrument/ClickTrack.scala
@@ -31,7 +31,8 @@ object ClickTrack:
   given Default[Settings] with
     val default: Settings = Settings()
 
-  val pattern: MusicalEvent = C4.medium.eighth * 8
+  val pattern: MusicalEvent =
+    (C4.medium.sixteenth + r16) * 8
 
   def track(instrument: ClickTrack): Track[Settings] =
     Track(Title("ClickTrack"), pattern, instrument, Playback.Loop)
@@ -51,7 +52,7 @@ final class ClickTrack private (
 
   def mute: IO[Unit] = mutedRef.set(true)
   def unmute: IO[Unit] = mutedRef.set(false)
-  def toggleMute: IO[Boolean] = mutedRef.modify(m => (!m, !m))
+  def toggleMute: IO[Boolean] = mutedRef.modify(muteStatus => (!muteStatus, !muteStatus))
   def isMuted: IO[Boolean] = mutedRef.get
 
   private val clickDuration = 0.05

--- a/js/src/main/scala/org/soundsofscala/models/Track.scala
+++ b/js/src/main/scala/org/soundsofscala/models/Track.scala
@@ -28,6 +28,17 @@ enum Playback:
 object Playback:
   given Eq[Playback] = Eq.fromUniversalEquals
 
+case class PlaybackLocation(
+    locatedEvent: MusicalEvent,
+    locatedBeatPosition: BeatPosition,
+    nextNoteTime: NextNoteTime)
+
+object Track:
+  extension (trackIndex: TrackIndex)
+    def resolveTrack(song: Song, clickTrack: Track[?]): Track[?] =
+      if trackIndex.value == 0 then clickTrack
+      else song.mixer.tracks.toList(trackIndex.value - 1)
+
 case class Track[Settings](
     title: Title,
     musicalEvent: MusicalEvent,

--- a/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/NoteScheduler.scala
@@ -20,15 +20,15 @@ import cats.effect.IO
 import cats.effect.Ref
 import org.scalajs.dom.AudioContext
 import org.soundsofscala.models.*
+import org.soundsofscala.models.Track.resolveTrack
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.DurationDouble
 
 /**
- * The `NoteScheduler` is responsible for scheduling the notes of a single track. It reads the
- * current Song from a `Ref[IO, Song]`, extracting the track by index. Tempo is re-read per-note for
- * live tempo changes. The track's pattern, instrument, and playback mode are re-read at each cycle
- * boundary.
+ * Walks through a track's `MusicalEvent` list note-by-note, scheduling each one against the
+ * `AudioContext` timeline. The Song is re-read from the Ref before every note, so tempo and pattern
+ * changes take effect immediately.
  *
  * @param songRef
  *   A Ref holding the current Song, re-read for live updates
@@ -38,132 +38,128 @@ import scala.concurrent.duration.DurationDouble
  *   The time window in seconds in which to schedule notes ahead of time
  */
 
-private case class PlaybackLocation(
-    locatedEvent: MusicalEvent,
-    locatedBeatPosition: BeatPosition,
-    adjustedNoteTime: NextNoteTime)
-
-private case class ScheduleContext(
-    trackIndex: TrackIndex,
-    initialEvent: MusicalEvent,
-    remainingEvent: MusicalEvent,
-    nextNoteTime: NextNoteTime,
-    beatPosition: BeatPosition,
-    startingBeatPosition: Option[BeatPosition],
-    swingCompensation: SwingOffset,
-    beatPositionOffset: Double = 0.0
-)
-
-final case class NoteScheduler(
+class NoteScheduler(
     songRef: Ref[IO, Song],
     beatPositionRef: Ref[IO, BeatPosition],
     lookAheadMs: LookAhead,
     scheduleAheadTimeSeconds: ScheduleWindow,
     clickTrack: Track[?]):
 
-  private def resolveTrack(trackIndex: TrackIndex, song: Song): Track[?] =
-    if trackIndex.value == 0 then clickTrack
-    else song.mixer.tracks.toList(trackIndex.value - 1)
-
-  def scheduleTrack(
+  private case class ScheduleContext(
       trackIndex: TrackIndex,
-      startingBeatPosition: Option[BeatPosition] = None
-  )(using ac: AudioContext): IO[Unit] =
-    def playCycle(
-        nextNoteTime: NextNoteTime,
-        beatOffset: Double,
-        resumePosition: Option[BeatPosition]
-    ): IO[Unit] =
-      for
-        song <- songRef.get
-        track = resolveTrack(trackIndex, song)
-        patternLength = totalDurationInBeats(track.musicalEvent)
-        localResume = resumePosition.map(bp => BeatPosition(bp.value % patternLength))
-        adjustedOffset = resumePosition.fold(beatOffset)(bp =>
-          bp.value - (bp.value % patternLength))
-        scheduleContext = ScheduleContext(
-          trackIndex,
-          initialEvent = track.musicalEvent,
-          remainingEvent = track.musicalEvent,
-          nextNoteTime,
-          BeatPosition(0.0),
-          localResume,
-          SwingOffset(0.0),
-          beatPositionOffset = adjustedOffset
-        )
-        finalNoteTime <- scheduleSequence(scheduleContext)
-        _ <-
-          track.playback match
-            case Playback.Loop =>
-              playCycle(finalNoteTime, adjustedOffset + patternLength, resumePosition = None)
-            case Playback.OneShot => IO.unit
-      yield ()
+      initialEvent: MusicalEvent,
+      remainingEvent: MusicalEvent,
+      nextNoteTime: NextNoteTime,
+      beatPosition: BeatPosition,
+      startingBeatPosition: Option[BeatPosition],
+      previousNoteSwingCompensation: SwingOffset,
+      absoluteBeatPositionBase: Double = 0.0
+  )
 
-    playCycle(NextNoteTime(ac.currentTime), beatOffset = 0.0, resumePosition = startingBeatPosition)
-  end scheduleTrack
+  def scheduleTrackSequence(
+      trackIndex: TrackIndex,
+      track: Track[?],
+      nextNoteTime: NextNoteTime,
+      startingBeatPosition: Option[BeatPosition],
+      absoluteBeatPositionBase: Double
+  )(using AudioContext): IO[NextNoteTime] =
+    val context = ScheduleContext(
+      trackIndex,
+      initialEvent = track.musicalEvent,
+      remainingEvent = track.musicalEvent,
+      nextNoteTime,
+      BeatPosition(0.0),
+      startingBeatPosition,
+      SwingOffset(0.0),
+      absoluteBeatPositionBase
+    )
+    scheduleSequence(context)
+
+  // ==================================
+  // Schedule Sequence
+  // ==================================
 
   private def scheduleSequence(context: ScheduleContext)(using AudioContext): IO[NextNoteTime] =
     ScheduleStatus.isReadyToSchedule(context.nextNoteTime, scheduleAheadTimeSeconds) match
+
       case ScheduleStatus.Waiting =>
         IO.sleep(lookAheadMs.value.millis) >> scheduleSequence(context)
+
       case ScheduleStatus.Ready =>
-        // read latest version of the song
         songRef.get.flatMap: song =>
-          val track = resolveTrack(context.trackIndex, song)
+          // we need to resolve the track from the song ref again here to get the latest version in case of live updates
+          val track = context.trackIndex.resolveTrack(song, clickTrack)
           val currentEventFromSongRef = track.musicalEvent
 
-          // this compares the event from the song ref with the original event specified when the song started playing
+          // this compares the event fetched from the song ref with the original event specified when the song started playing
           if currentEventFromSongRef != context.initialEvent
-            // If changed then updated sequence and call this scheduleSequence method again
+            // if the event has changed, we need to apply a live update and call scheduleSequence again
           then applyLiveUpdate(context, currentEventFromSongRef, song)
-          else playNextNote(context, song)
+          else playNextNote(context, track, song)
 
-  private def playNextNote(context: ScheduleContext, song: Song)(
+  // ==================================
+  // Play Next Note
+  // ==================================
+
+  private def playNextNote(context: ScheduleContext, track: Track[?], song: Song)(
       using AudioContext): IO[NextNoteTime] =
-    val track = resolveTrack(context.trackIndex, song)
-    val swingInMillis = calculateSwingOffset(song)
 
-    def calculateNextNoteTime(
-        baseTime: NextNoteTime,
-        note: AtomicMusicalEvent,
-        swingOffset: Double): NextNoteTime =
-      NextNoteTime(
-        baseTime.value + swingOffset + context.swingCompensation.value + note
-          .durationToSeconds(song.tempo))
+    val playBackLocation = locatePositionToStartPlayback(context, song.tempo)
 
-    val playBackLocation = locatePlaybackPosition(context, song.tempo)
     playBackLocation.locatedEvent match
+
       case sequence: Sequence =>
         val updatedBeatPosition =
-          incrementBeatPosition(playBackLocation.locatedBeatPosition, sequence.head)
-        val swingOffset =
-          if updatedBeatPosition.isSwungBeat(song.swing) then swingInMillis else 0.0
-        val nextNextNoteTime =
-          calculateNextNoteTime(playBackLocation.adjustedNoteTime, sequence.head, swingOffset)
-        IO.whenA(context.trackIndex.value == 0)(beatPositionRef.set(
-          BeatPosition(updatedBeatPosition.value + context.beatPositionOffset))) >>
-          track.playAtomicMusicalEvent(
+          addNoteDurationToBeatPosition(playBackLocation.locatedBeatPosition, sequence.head)
+
+        val (followingNoteTime, swingCompensation) = calculateNextNoteTime(
+          playBackLocation.nextNoteTime,
+          sequence.head,
+          updatedBeatPosition,
+          song,
+          context.previousNoteSwingCompensation)
+
+        for
+          _ <- updateBeatPositionTimeline(context, updatedBeatPosition)
+          _ <- track.playAtomicMusicalEvent(
             sequence.head,
-            playBackLocation.adjustedNoteTime.value,
-            song.tempo) >>
-          scheduleSequence(context.copy(
+            playBackLocation.nextNoteTime.value,
+            song.tempo)
+          result <- scheduleSequence(context.copy(
             remainingEvent = sequence.tail,
-            nextNoteTime = nextNextNoteTime,
+            nextNoteTime = followingNoteTime,
             beatPosition = updatedBeatPosition,
             startingBeatPosition = None,
-            swingCompensation = SwingOffset.compensation(swingOffset)
+            previousNoteSwingCompensation = swingCompensation
           ))
+        yield result
+
       case atomicEvent: AtomicMusicalEvent =>
         val updatedBeatPosition =
-          incrementBeatPosition(playBackLocation.locatedBeatPosition, atomicEvent)
-        val nextNextNoteTime =
-          calculateNextNoteTime(playBackLocation.adjustedNoteTime, atomicEvent, swingOffset = 0.0)
-        IO.whenA(context.trackIndex.value == 0)(beatPositionRef.set(
-          BeatPosition(updatedBeatPosition.value + context.beatPositionOffset))) >>
-          track.playAtomicMusicalEvent(atomicEvent, context.nextNoteTime.value, song.tempo)
-            .as(nextNextNoteTime)
-    end match
-  end playNextNote
+          addNoteDurationToBeatPosition(playBackLocation.locatedBeatPosition, atomicEvent)
+        val (followingNoteTime, _) = calculateNextNoteTime(
+          playBackLocation.nextNoteTime,
+          atomicEvent,
+          updatedBeatPosition,
+          song,
+          context.previousNoteSwingCompensation)
+
+        for
+          _ <- updateBeatPositionTimeline(context, updatedBeatPosition)
+          _ <- track.playAtomicMusicalEvent(atomicEvent, context.nextNoteTime.value, song.tempo)
+        yield followingNoteTime
+
+  // ==================================
+  // Utility methods - ScheduleSequence
+  // ==================================
+
+  private val updateBeatPositionTimeline: (ScheduleContext, BeatPosition) => IO[Unit] =
+    (context: ScheduleContext, updatedBeatPosition: BeatPosition) =>
+      IO.whenA(isClickTrack(context.trackIndex))(beatPositionRef.set(
+        BeatPosition(updatedBeatPosition.value + context.absoluteBeatPositionBase)))
+
+  private val isClickTrack: TrackIndex => Boolean =
+    (trackIndex: TrackIndex) => trackIndex.value == 0
 
   private def applyLiveUpdate(
       context: ScheduleContext,
@@ -174,13 +170,13 @@ final case class NoteScheduler(
     val (eventFromCurrentPosition, currentBeatPosition) =
       findEventAtBeatPosition(updatedEvent, context.beatPosition)
 
-    val adjustedNoteTime = adjustNoteTimeForBeatOffset(
+    val adjustedNoteTime = alignNoteTimeToActualBeatPosition(
       context.nextNoteTime,
       context.beatPosition,
       currentBeatPosition,
       song.tempo)
 
-    // call schedule sequence again with event from current position & timing
+    // call schedule sequence again with the Event from current position & timing
     scheduleSequence(context.copy(
       initialEvent = updatedEvent,
       remainingEvent = eventFromCurrentPosition,
@@ -188,53 +184,46 @@ final case class NoteScheduler(
       beatPosition = currentBeatPosition
     ))
 
-  private def locatePlaybackPosition(
-      context: ScheduleContext,
-      tempo: Tempo): PlaybackLocation =
-    context.startingBeatPosition.fold(
-      PlaybackLocation(context.remainingEvent, context.beatPosition, context.nextNoteTime)
-    ) { target =>
-      val (event, beatPos) = findEventAtBeatPosition(context.remainingEvent, target)
-      val adjustedNoteTime = adjustNoteTimeForBeatOffset(
-        context.nextNoteTime,
-        target,
-        beatPos,
-        tempo)
-      PlaybackLocation(event, beatPos, adjustedNoteTime)
-    }
+  private val locatePositionToStartPlayback: (ScheduleContext, Tempo) => PlaybackLocation =
+    (context: ScheduleContext, tempo: Tempo) =>
+      context.startingBeatPosition.fold(
+        PlaybackLocation(context.remainingEvent, context.beatPosition, context.nextNoteTime)
+      ) { target =>
+        val (event, beatPos) = findEventAtBeatPosition(context.remainingEvent, target)
+        val adjustedNoteTime = alignNoteTimeToActualBeatPosition(
+          context.nextNoteTime,
+          target,
+          beatPos,
+          tempo)
+        PlaybackLocation(event, beatPos, adjustedNoteTime)
+      }
 
-  /*
-  Compensating - Event Boundary
-
-  A mismatch happens when two tracks have different subdivision patterns
-  I found this with the hi-hats being 8ths and kick being quarter notes
-
-  Say you resume or create a live update at beat 3.5
-
-  Kick (quarter notes, boundaries at 0, 1, 2, 3, 4):
-  findEventAtBeatPosition walks: 0 → 1 → 2 → 3 (3 < 3.5, keep going) → 4 (4 >= 3.5, stop).
-  Lands at beat 4.0.
-
-  Hihats (eighth notes, boundaries at 0, 0.5, 1.0, ... 3.0, 3.5, 4.0):
-  Walks: 0 → 0.5 → ... → 3.0 → 3.5 (3.5 >= 3.5, stop). Lands at beat 3.5.
-
-  Without the adjustment, both would play their first note at the same AudioContext.currentTime
-  but the kick is at beat 4.0 and the hihat is at beat 3.5.
-  That's half a beat apart, so they'd be out of sync.
-
-  adjustNoteTimeForBeatOffset fixes it: the kick landed 0.5 beats past the target,
-  so its first note gets pushed forward by 0.5 beats worth of seconds.
-  Now the kick plays at the correct time for beat 4.0 and the hihat
-  at the correct time for beat 3.5.
-
-  This method compensates for that gap.
-  It takes the difference between where you landed (actualBeatPosition)
-  and where you wanted to be (expectedBeatPosition), converts that from
-  beats to seconds using the tempo, and shifts noteTime forward by that amount.
-  So the note plays at the correct AudioContext time for the beat it's actually at.
+  /**
+   * alignNoteTimeToActualBeatPosition - The ballad of why this method exists
+   *
+   * This is all brought on by resume playback.
+   *
+   * A mismatch happens when two tracks have different subdivision patterns - I found this with the
+   * hi-hats being 8ths and kick being quarter notes
+   *
+   * Say you resume or create a live update at beat 3.5
+   *
+   * Kick (quarter notes, boundaries at 0, 1, 2, 3, 4): findEventAtBeatPosition walks: 0 → 1 → 2 → 3
+   * (3 < 3.5, keep going) → 4 (4 >= 3.5, stop). Lands at beat 4.0.
+   *
+   * Hihats (eighth notes, boundaries at 0, 0.5, 1.0, ... 3.0, 3.5, 4.0): Walks: 0 → 0.5 → ... → 3.0
+   * → 3.5 (3.5 >= 3.5, stop). Lands at beat 3.5.
+   *
+   * Without the adjustment, both would play their first note at the same AudioContext.currentTime
+   * but the kick is at beat 4.0 and the hihat is at beat 3.5. That's half a beat apart, so they'd
+   * be out of sync.
+   *
+   * This method fixes it: the kick landed 0.5 beats past the target, so its noteTime gets delayed
+   * by 0.5 beats worth of seconds. Now the kick plays at the correct time for beat 4.0 and the
+   * hihat at the correct time for beat 3.5.
    */
 
-  private def adjustNoteTimeForBeatOffset(
+  private def alignNoteTimeToActualBeatPosition(
       noteTime: NextNoteTime,
       expectedBeatPosition: BeatPosition,
       actualBeatPosition: BeatPosition,
@@ -242,7 +231,6 @@ final case class NoteScheduler(
     val beatOffset = actualBeatPosition.value - expectedBeatPosition.value
     val secondsPerBeat = 60.0 / tempo.value
     NextNoteTime(noteTime.value + beatOffset * secondsPerBeat)
-  end adjustNoteTimeForBeatOffset
 
   /*
   Iterates through sequence from start - Returns the remaining sequence
@@ -273,27 +261,35 @@ final case class NoteScheduler(
     // start from the beginning and find event at targetBeatPosition
     loop(event, BeatPosition(0.0))
 
-  @tailrec
-  private def totalDurationInBeats(event: MusicalEvent, acc: Double = 0.0): Double =
-    event match
-      case sequence: Sequence =>
-        totalDurationInBeats(sequence.tail, acc + sequence.head.durationToBeats)
-      case atomic: AtomicMusicalEvent => acc + atomic.durationToBeats
+  private val calculateSwingOffset: Song => SwingOffset =
+    (song: Song) =>
+      val swingFromTempo = song.swing.amount.value.toDouble / 1000.0 * (60.0 / song.tempo.value)
+      SwingOffset(song.swing.resolution match
+        case SwingResolution.Eighth => swingFromTempo * 20
+        case SwingResolution.Sixteenth => swingFromTempo * 16
+      )
 
-  private def calculateSwingOffset(song: Song): Double =
-    val swingFromTempo = song.swing.amount.value.toDouble / 1000.0 * (60.0 / song.tempo.value)
-    song.swing.resolution match
-      case SwingResolution.Eighth => swingFromTempo * 20
-      case SwingResolution.Sixteenth => swingFromTempo * 16
+  private def calculateNextNoteTime(
+      currentNoteTime: NextNoteTime,
+      event: AtomicMusicalEvent,
+      nextBeatPosition: BeatPosition,
+      song: Song,
+      previousSwingCompensation: SwingOffset
+  ): (nextNoteTime: NextNoteTime, swingCompensation: SwingOffset) =
+    val swingOffset =
+      if nextBeatPosition.isSwungBeat(song.swing) then calculateSwingOffset(song)
+      else SwingOffset.none
+    val nextNoteTime = NextNoteTime(
+      currentNoteTime.value + swingOffset.value + previousSwingCompensation.value + event.durationToSeconds(
+        song.tempo))
+    (nextNoteTime, SwingOffset.compensation(swingOffset.value))
 
-  private def incrementBeatPosition(
-      currentBeatPosition: BeatPosition,
-      sequence: MusicalEvent): BeatPosition =
-    val durationInBeats = sequence match
-      case Sequence(head, tail) => head.durationToBeats
-      case e: AtomicMusicalEvent => e.durationToBeats
-
-    BeatPosition(currentBeatPosition.value + durationInBeats)
+  private val addNoteDurationToBeatPosition: (BeatPosition, MusicalEvent) => BeatPosition =
+    (currentBeatPosition: BeatPosition, sequence: MusicalEvent) =>
+      val durationInBeats = sequence match
+        case Sequence(head, tail) => head.durationToBeats
+        case e: AtomicMusicalEvent => e.durationToBeats
+      BeatPosition(currentBeatPosition.value + durationInBeats)
 
   extension (beatPosition: BeatPosition)
     def isSwungBeat(swing: Swing): Boolean =

--- a/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/Sequencer.scala
@@ -25,97 +25,211 @@ import org.soundsofscala.instrument.ClickTrack
 import org.soundsofscala.models.*
 
 /**
- * The sequencer is responsible for scheduling the notes of every track in the song in parallel. It
- * holds a `Ref[IO, Song]` so that all song properties (tempo, swing, track patterns, instruments,
- * etc.) can be updated in real time via the same Ref.
+ * The Sequencer class is the key piece of Kit in the Sounds of Scala library for playing musical
+ * events.
  *
- * To change the song being played, update the Song inside the Ref — don't create a new Sequencer.
+ * It orchestrates parallel playback of all tracks in a song. The Song is held in a `Ref[IO, Song]`
+ * so that tempo, swing, patterns, and instruments can be updated in real time.
  *
- * @param songRef
- *   A Ref holding the current Song, enabling live updates to any property
- * @param beatPositionRef
- *   A Ref containing the current beat position while playing
- * @param pausedAtRef
- *   A Ref holding beat position of song when paused
+ * To change the song being played, update the Song inside the Ref - don't create a new Sequencer.
+ *
+ * KEY FEATURES:
+ *
+ * ====Lookahead Scheduling====
+ *
+ * The sequencer uses a lookahead to schedule notes in advance. This ensures notes are played in the
+ * correct order and at the correct time on a single-threaded JavaScript runtime. The lookahead is
+ * set to 25ms by default and can be changed by passing a different lookahead value to the Sequencer
+ * constructor.. Based on: [[https://web.dev/articles/audio-scheduling Audio Scheduling]]
+ *
+ * It seems unlikely you'd need to change the lookahead value but the option is there in the event
+ * you encounter performance issues.
+ *
+ * ====Click Track====
+ *
+ * The click track has two purposes:
+ *
+ *   1. BEAT POSITION - It owns the song's beat position, advancing the beatPositionRef at 16th-note
+ *      resolution (0.25 beat increments),
+ *
+ * This serves as the master timeline that other tracks and the UI reference for scheduling,
+ * pause/resume, and display.
+ *
+ * 2. METRONOME - It provides an audible metronome click for the user to play along with / keep
+ * time.
+ *
+ * ====Live Updates====
+ *
+ * Live song updates so you can change the song while it is playing has been added and is enabled by
+ * passing a Cats Effect Ref to the Sequencer constructor.
+ *
+ * FUTURE CONSIDERATION: It may be possible to encapsulate the Ref in the sequencer itself and can
+ * look into this in future releases.
+ *
+ * ====Looping Tracks====
+ *
+ * We have added the capability of looping tracks to the sequencer. This is determined by the
+ * Playback enum in the Track class and the TrackScheduler owns handling the looping logic.
+ *
+ * ====Resume Playback====
+ *
+ * This was a feature required by the 'Pause' functionality. It means a song can be resumed from any
+ * point in the song. Up until this point we had no concept of tracking the location of the song.
+ * Two ways of doing this were considered:
+ *
+ *   1. Using the AudioContext.currentTime to track the time of the song in minutes, seconds and
+ *      milliseconds.
+ *
+ * 2. Using a custom timekeeping system by beats and sub beats.
+ *
+ * We have started with the second option and are using a custom timekeeping system by beats and sub
+ * beats. This allows us to track the location of the song at any point in the song. This is done by
+ * keeping a record of the beat position as defined by the click track. As stated above, the beat
+ * position is updated by the click track at 16th note resolution (0.25 beat increments).
+ *
+ * BEAT OFFSET - this arose from the fact that different tracks have different subdivision patterns
+ * at the point of resuming playback. When first playing back a song.. different tracks played back
+ * at different times so we needed to calculate the offset to ensure all tracks played back at the
+ * same time.
+ *
+ * The TrackScheduler is responsible for calculating the beat offset and passing it to the
+ * NoteScheduler.
+ *
+ * ====Swing Calculation====
+ *
+ * We recently added the capability of adding swing to a sequence of notes at different strengths.
+ * This is done by calculating the swing offset for each note in the sequence. It ultimatelymeans
+ * adding some time to a note, and then subtracting some time from the next note.
  */
 
-class Sequencer private (
-    val songRef: Ref[IO, Song],
-    private val fiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
-    private val beatPositionRef: Ref[IO, BeatPosition],
-    private val pausedAtRef: Ref[IO, Option[BeatPosition]],
-    val clickTrack: ClickTrack
-)(using audioContext: AudioContext):
+trait Sequencer:
+  /**
+   * Updates the Song in real time.
+   */
+  def updateSong(updateFunction: Song => Song): IO[Unit]
 
-  def updateSong(f: Song => Song): IO[Unit] = songRef.update(f)
+  /**
+   * Returns the current beat position of the song while the song is playing.
+   */
+  def currentBeatPosition: IO[BeatPosition]
 
-  def currentBeatPosition: IO[BeatPosition] = beatPositionRef.get
+  def toggleClickOnOff: IO[Boolean]
 
-  def toggleClick: IO[Boolean] = clickTrack.toggleMute
+  def play(): IO[Unit]
 
-  def play(): IO[Unit] =
-    for
-      song <- songRef.get
-      pausedAt <- pausedAtRef.get
-      _ <- IO.println(pausedAt.fold(s"Playing: ${song.title}")(bp =>
-        s"Resuming: ${song.title} from beat ${bp.value}"))
-      _ <- stop()
-      fiber <- startPlaybackFromBeat(pausedAt).start
-      _ <- fiberRef.set(fiber.some)
-    yield ()
+  /**
+   * Does indeed stop playback but notably resets the position to the start.
+   */
+  def stop(): IO[Unit]
 
-  def stop(): IO[Unit] =
-    fiberRef.getAndSet(none).flatMap:
-      case Some(fiber) =>
-        IO.println("Stopping sequencer") *>
-          fiber.cancel *>
-          stopInstruments() *>
-          beatPositionRef.set(BeatPosition(0.0)) *>
-          pausedAtRef.set(none)
-      case none => IO.unit
+  /**
+   * Pauses playback, preserving the current beat position for resume.
+   */
+  def pause(): IO[Unit]
 
-  def pause(): IO[Unit] =
-    for
-      _ <- fiberRef.getAndSet(none).flatMap {
-        case Some(fiber) =>
-          fiber.cancel *>
-            stopInstruments()
-        case none => IO.unit
-      }
-      beatPosition <- beatPositionRef.get
-      _ <- pausedAtRef.set(beatPosition.some)
-      _ <- IO.println(s"Paused at beat: ${beatPosition.value}")
-    yield ()
-
-  private def stopInstruments(): IO[Unit] =
-    clickTrack.stop.void *>
-      songRef.get.flatMap(_.mixer.tracks.parTraverse(_.instrument.stop.void).void)
-
-  private def startPlaybackFromBeat(positionToStartAt: Option[BeatPosition]): IO[Unit] =
-    positionToStartAt.fold(IO.unit)(beatPositionRef.set) >>
-      songRef.get.flatMap: song =>
-        val noteScheduler =
-          NoteScheduler(
-            songRef,
-            beatPositionRef,
-            LookAhead(25),
-            ScheduleWindow(0.1),
-            ClickTrack.track(clickTrack))
-
-        val scheduleClick = noteScheduler.scheduleTrack(TrackIndex(0), positionToStartAt)
-        val scheduleSongTracks = (1 to song.mixer.tracks.size).toList.parTraverse: index =>
-          noteScheduler.scheduleTrack(TrackIndex(index), positionToStartAt)
-
-        // We use IO.race to stop the click track when the song finishes
-        IO.race(scheduleSongTracks.void, scheduleClick).void *>
-          songRef.get.flatMap(song => IO.println(s"Finished playing: ${song.title}"))
+  /**
+   * Starts playback from a specific beat position.
+   */
+  def startPlaybackFromBeat(barPositionToStartAt: Option[BeatPosition]): IO[Unit]
 end Sequencer
 
 object Sequencer:
-  def apply(songRef: Ref[IO, Song])(using AudioContext): IO[Sequencer] =
+  def apply(
+      songRef: Ref[IO, Song],
+      lookAhead: LookAhead = LookAhead(25),
+      scheduleWindow: ScheduleWindow = ScheduleWindow(0.1)
+  )(using AudioContext): IO[Sequencer] =
     for
       fiberRef <- Ref.of[IO, Option[Fiber[IO, Throwable, Unit]]](none)
       beatPositionRef <- Ref.of[IO, BeatPosition](BeatPosition(0.0))
       pausedAtRef <- Ref.of[IO, Option[BeatPosition]](None)
       clickTrack <- ClickTrack()
-    yield new Sequencer(songRef, fiberRef, beatPositionRef, pausedAtRef, clickTrack)
+    yield new SequencerImpl(
+      songRef,
+      fiberRef,
+      beatPositionRef,
+      pausedAtRef,
+      clickTrack,
+      lookAhead,
+      scheduleWindow)
+
+  private class SequencerImpl(
+      songRef: Ref[IO, Song],
+      fiberRef: Ref[IO, Option[Fiber[IO, Throwable, Unit]]],
+      beatPositionRef: Ref[IO, BeatPosition],
+      pausedAtRef: Ref[IO, Option[BeatPosition]],
+      clickTrack: ClickTrack,
+      lookAhead: LookAhead,
+      scheduleWindow: ScheduleWindow
+  )(using audioContext: AudioContext)
+      extends Sequencer:
+
+    def updateSong(updateFunction: Song => Song): IO[Unit] = songRef.update(updateFunction)
+
+    def currentBeatPosition: IO[BeatPosition] = beatPositionRef.get
+
+    def toggleClickOnOff: IO[Boolean] = clickTrack.toggleMute
+
+    def play(): IO[Unit] =
+      for
+        song <- songRef.get
+        pausedAt <- pausedAtRef.get
+        _ <- IO.println(pausedAt.fold(s"Playing: ${song.title}")(beatPosition =>
+          s"Resuming: ${song.title} from beat ${beatPosition.value}"))
+        _ <- stop()
+        fiber <- startPlaybackFromBeat(pausedAt).start
+        _ <- fiberRef.set(fiber.some)
+      yield ()
+
+    def stop(): IO[Unit] =
+      fiberRef.getAndSet(none).flatMap:
+        case Some(fiber) =>
+          IO.println("Stopping sequencer") *>
+            fiber.cancel *>
+            stopInstruments() *>
+            beatPositionRef.set(BeatPosition(0.0)) *>
+            pausedAtRef.set(none)
+        case none => IO.unit
+
+    def pause(): IO[Unit] =
+      for
+        _ <- fiberRef.getAndSet(none).flatMap {
+          case Some(fiber) =>
+            fiber.cancel *>
+              stopInstruments()
+          case none => IO.unit
+        }
+        beatPosition <- beatPositionRef.get
+        _ <- pausedAtRef.set(beatPosition.some)
+        _ <- IO.println(s"Paused at beat: ${beatPosition.value}")
+      yield ()
+
+    private def stopInstruments(): IO[Unit] =
+      clickTrack.stop.void *>
+        songRef.get.flatMap(_.mixer.tracks.parTraverse(_.instrument.stop.void).void)
+
+    def startPlaybackFromBeat(barPositionToStartAt: Option[BeatPosition]): IO[Unit] =
+      barPositionToStartAt.fold(IO.unit)(beatPositionRef.set) >>
+        songRef.get.flatMap: song =>
+          val trackScheduler =
+            TrackScheduler(
+              songRef,
+              beatPositionRef,
+              lookAhead,
+              scheduleWindow,
+              ClickTrack.track(clickTrack))
+
+          val scheduleClick = trackScheduler.scheduleTrack(TrackIndex(0), barPositionToStartAt)
+
+          val scheduleSongTracks = (1 to song.mixer.tracks.size).toList.parTraverse: index =>
+            trackScheduler.scheduleTrack(TrackIndex(index), barPositionToStartAt)
+
+          /**
+           * Using race here essentially to stop the click track from playing once the song track
+           * ends. The clicks musical event loops infinitely and needs to be conditional on the
+           * song..
+           */
+          IO.race(scheduleSongTracks.void, scheduleClick).void *>
+            songRef.get.flatMap(song => IO.println(s"Finished playing: ${song.title}"))
+  end SequencerImpl
+end Sequencer

--- a/js/src/main/scala/org/soundsofscala/transport/TrackScheduler.scala
+++ b/js/src/main/scala/org/soundsofscala/transport/TrackScheduler.scala
@@ -1,0 +1,144 @@
+package org.soundsofscala.transport
+
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cats.effect.IO
+import cats.effect.Ref
+import cats.syntax.all.*
+import org.scalajs.dom.AudioContext
+import org.soundsofscala.models.*
+import org.soundsofscala.models.Track.resolveTrack
+
+/**
+ * Manages the lifecycle of a single track's playback. Owns the logic for handling loop/one-shot
+ * behavior.
+ *
+ *   1. Reads the current Song from a `Ref[IO, Song]`, extracting the track by index.
+ *
+ * 2. Calculates where to resume playback from.
+ *
+ * 3. Calculates the beat offset needed for notes of different lengths at resume position. Takes
+ * into acccout looping.
+ *
+ * 4. Hands off to the NoteScheduler to schedule the notes.
+ */
+class TrackScheduler(
+    songRef: Ref[IO, Song],
+    beatPositionRef: Ref[IO, BeatPosition],
+    lookAheadMs: LookAhead,
+    scheduleAheadTimeSeconds: ScheduleWindow,
+    clickTrack: Track[?]):
+
+  private val noteScheduler =
+    NoteScheduler(songRef, beatPositionRef, lookAheadMs, scheduleAheadTimeSeconds, clickTrack)
+
+  def scheduleTrack(
+      trackIndex: TrackIndex,
+      startingBeatPosition: Option[BeatPosition] = none
+  )(using audioContext: AudioContext): IO[Unit] =
+
+    // the convention of using 'loop' for our recursive function is pretty apt here
+    def loop(
+        nextNoteTime: NextNoteTime,
+        songPositionToResumeAt: Option[BeatPosition],
+        beatOffsetForResume: Double
+    ): IO[Unit] =
+      for
+        song <- songRef.get
+        track = trackIndex.resolveTrack(song, clickTrack)
+        _ <- track.playback match
+
+          case Playback.OneShot =>
+            noteScheduler.scheduleTrackSequence(
+              trackIndex,
+              track,
+              nextNoteTime,
+              startingBeatPosition = songPositionToResumeAt,
+              absoluteBeatPositionBase = 0.0
+            ).void
+
+          case Playback.Loop =>
+            val (beatPositionInLoop, completedLoopsBeatCount, nextLoopCompletedBeatCount) =
+              resolveLoopPlaybackPosition(track, songPositionToResumeAt, beatOffsetForResume)
+            noteScheduler.scheduleTrackSequence(
+              trackIndex,
+              track,
+              nextNoteTime,
+              startingBeatPosition = beatPositionInLoop,
+              absoluteBeatPositionBase = completedLoopsBeatCount
+            ).flatMap(finalNoteTime =>
+              loop(finalNoteTime, songPositionToResumeAt = none, nextLoopCompletedBeatCount))
+      yield ()
+
+    val playbackStartTime = NextNoteTime(audioContext.currentTime)
+
+    /**
+     * Starting the loop with the current time and a beat offset of 0.0.
+     */
+    loop(
+      playbackStartTime,
+      songPositionToResumeAt = startingBeatPosition,
+      beatOffsetForResume = 0.0
+    )
+  end scheduleTrack
+
+  /**
+   * When resuming playback (e.g. after pause), the beat position may land partway through a looped
+   * sequence. For example, pausing at beat 5.0 on a 4-beat loop means we need to resume at beat 1.0
+   * within the pattern (5.0 % 4.0 = 1.0).
+   *
+   * The beat offset accounts for how many complete loops have already elapsed. This is important
+   * because the `beatPositionRef` (used for UI display and pause/resume) needs to reflect the
+   * absolute position in the song, not just the position within the current loop iteration.
+   *
+   * Without this offset, every loop restart would reset the beat position to 0, losing track of
+   * where we actually are in the song timeline.
+   *
+   * @param track
+   *   The track whose musical event defines the loop length
+   * @param songPositionToResumeAt
+   *   The absolute beat position to resume from (e.g. 5.0), or None if starting fresh
+   * @param currentBeatOffset
+   *   The accumulated beat offset from previous loop iterations
+   * @return
+   *   A tuple of:
+   *   - The beat position within the current loop iteration to resume from (e.g. 1.0)
+   *   - The total beats from completed loop iterations (so beatPositionRef reflects absolute song
+   *     position)
+   *   - The beat offset to pass to the next loop iteration (completed loops + one full pattern
+   *     length)
+   */
+  private def resolveLoopPlaybackPosition(
+      track: Track[?],
+      songPositionToResumeAt: Option[BeatPosition],
+      currentBeatOffset: Double
+  ): (Option[BeatPosition], Double, Double) =
+    val totalBeatsInEvent = track.musicalEvent.totalDurationInBeats
+
+    // what part of the loop to play
+    val beatPositionInLoopToResumeAt =
+      songPositionToResumeAt.map(position => BeatPosition(position.value % totalBeatsInEvent))
+
+    // how many beats of completed loops have elapsed before this - keep track of absolute song position
+    val completedLoopsBeatCount = songPositionToResumeAt.fold(currentBeatOffset)(position =>
+      position.value - (position.value % totalBeatsInEvent))
+
+    val nextLoopCompletedBeatCount = completedLoopsBeatCount + totalBeatsInEvent
+
+    (beatPositionInLoopToResumeAt, completedLoopsBeatCount, nextLoopCompletedBeatCount)
+  end resolveLoopPlaybackPosition
+end TrackScheduler

--- a/js/src/test/scala/org/soundsofscala/TestUtils.scala
+++ b/js/src/test/scala/org/soundsofscala/TestUtils.scala
@@ -1,0 +1,9 @@
+package org.soundsofscala
+
+import org.scalajs.dom.AudioContext
+
+import scala.scalajs.js
+
+object TestUtils:
+  def stubAudioContext: AudioContext =
+    js.Dynamic.literal(currentTime = 0.0).asInstanceOf[AudioContext]

--- a/js/src/test/scala/org/soundsofscala/transport/NoteSchedulerTest.scala
+++ b/js/src/test/scala/org/soundsofscala/transport/NoteSchedulerTest.scala
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.soundsofscala.transport
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.Ref
+import cats.syntax.all.*
+import org.scalajs.dom.AudioContext
+import org.soundsofscala.TestUtils
+import org.soundsofscala.instrument.Default.NoSettings
+import org.soundsofscala.instrument.NoInstrument
+import org.soundsofscala.models.*
+import org.soundsofscala.models.AtomicMusicalEvent.Rest
+import org.soundsofscala.models.Duration.*
+import org.soundsofscala.models.Track.resolveTrack
+import org.soundsofscala.syntax.all.*
+import weaver.SimpleIOSuite
+
+object NoteSchedulerTest extends SimpleIOSuite:
+
+  given AudioContext = TestUtils.stubAudioContext
+
+  private val tempo120 = Tempo(120) // quarter note = 0.5s
+  private val tempo60 = Tempo(60) // quarter note = 1.0s
+  private val noSwing = Swing(SwingAmount(0), SwingResolution.Eighth)
+  private val scheduleWindow = ScheduleWindow(10.0)
+  private val lookAhead = LookAhead(25)
+
+  private val clickTrackEvent: MusicalEvent = (C4.medium.sixteenth + Rest(Sixteenth)) * 8
+  private val clickTrackTrack: Track[NoSettings] =
+    Track(Title("Click"), clickTrackEvent, NoInstrument[NoSettings](), Playback.Loop)
+
+  private def makeSong(event: MusicalEvent, tempo: Tempo = tempo120, swing: Swing = noSwing): Song =
+    Song(
+      title = Title("Test"),
+      tempo = tempo,
+      swing = swing,
+      mixer = Mixer(NonEmptyList.one(
+        Track(Title("Track 1"), event, NoInstrument[NoSettings](), Playback.OneShot)
+      ))
+    )
+
+  private def trackFor(trackIndex: TrackIndex, song: Song): Track[?] =
+    trackIndex.resolveTrack(song, clickTrackTrack)
+
+  private def makeScheduler(song: Song): IO[(NoteScheduler, Ref[IO, Song], Ref[IO, BeatPosition])] =
+    for
+      songRef <- Ref.of[IO, Song](song)
+      beatPositionRef <- Ref.of[IO, BeatPosition](BeatPosition(0.0))
+      scheduler =
+        NoteScheduler(songRef, beatPositionRef, lookAhead, scheduleWindow, clickTrackTrack)
+    yield (scheduler, songRef, beatPositionRef)
+
+  // --- Basic scheduling ---
+
+  test("single quarter note at 120 BPM returns correct NextNoteTime"):
+    val song = makeSong(C4.medium.quarter)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 0.5))
+
+  test("single quarter note at 60 BPM returns correct NextNoteTime"):
+    val song = makeSong(C4.medium.quarter, tempo = tempo60)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 1.0))
+
+  test("sequence of 4 quarter notes at 120 BPM returns NextNoteTime of 2.0"):
+    val song = makeSong(C4.medium.quarter * 4)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 2.0))
+
+  test("sequence of 8 eighth notes at 120 BPM returns NextNoteTime of 2.0"):
+    val song = makeSong(C4.medium.eighth * 8)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 2.0))
+
+  test("mixed durations sum correctly"):
+    val event = C4.medium.half + D4.medium.quarter + E4.medium.eighth
+    val song = makeSong(event)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 1.75))
+
+  test("rest notes are scheduled with correct timing"):
+    val event = Rest(Quarter) + C4.medium.quarter
+    val song = makeSong(event)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 1.0))
+
+  test("non-zero start time offsets the result"):
+    val song = makeSong(C4.medium.quarter)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(5.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 5.5))
+
+  // --- Beat position tracking ---
+
+  test("beat position is updated for click track (index 0)"):
+    val song = makeSong(C4.medium.quarter * 4)
+    makeScheduler(song).flatMap: (scheduler, _, beatPositionRef) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(0),
+          trackFor(TrackIndex(0), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .flatMap(_ => beatPositionRef.get)
+        .map(beatPosition => expect.eql(beatPosition.value, 4.0))
+
+  test("beat position is NOT updated for non-click tracks"):
+    val song = makeSong(C4.medium.quarter * 4)
+    makeScheduler(song).flatMap: (scheduler, _, beatPositionRef) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .flatMap(_ => beatPositionRef.get)
+        .map(beatPosition => expect.eql(beatPosition.value, 0.0))
+
+  test("beat position includes absoluteBeatPositionBase for click track"):
+    val song = makeSong(C4.medium.quarter * 2)
+    makeScheduler(song).flatMap: (scheduler, _, beatPositionRef) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(0),
+          trackFor(TrackIndex(0), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 8.0)
+        .flatMap(_ => beatPositionRef.get)
+        .map(beatPosition => expect.eql(beatPosition.value, 12.0))
+
+  // --- Live updates ---
+
+  test("live update picks up changed pattern mid-sequence"):
+    val originalEvent = C4.medium.quarter * 4
+    val updatedEvent = C4.medium.eighth * 4
+    val song = makeSong(originalEvent)
+    makeScheduler(song).flatMap: (scheduler, songRef, _) =>
+      songRef.set(makeSong(updatedEvent)) >>
+        scheduler
+          .scheduleTrackSequence(
+            TrackIndex(1),
+            trackFor(TrackIndex(1), song),
+            NextNoteTime(0.0),
+            none,
+            absoluteBeatPositionBase = 0.0)
+          .map(result => expect.eql(result.value, 1.0))
+
+  // --- Resume from beat position ---
+
+  test("resume from beat position 2.0 skips first two quarter notes"):
+    val song = makeSong(C4.medium.quarter * 4)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          startingBeatPosition = BeatPosition(2.0).some,
+          absoluteBeatPositionBase = 0.0
+        )
+        .map(result => expect.eql(result.value, 1.0))
+
+  test("resume from beat position 1.0 with eighth notes"):
+    val song = makeSong(C4.medium.eighth * 8)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          startingBeatPosition = BeatPosition(1.0).some,
+          absoluteBeatPositionBase = 0.0
+        )
+        .map(result => expect.eql(result.value, 1.5))
+
+  // --- Swing ---
+
+  test("swing offsets are applied to swung beats"):
+    val withSwing = Swing(SwingAmount(5), SwingResolution.Eighth)
+    val event = C4.medium.eighth * 4
+    val songNoSwing = makeSong(event, swing = noSwing)
+    val songWithSwing = makeSong(event, swing = withSwing)
+
+    for
+      (schedulerNoSwing, _, _) <- makeScheduler(songNoSwing)
+      (schedulerWithSwing, _, _) <- makeScheduler(songWithSwing)
+      noSwingTime <- schedulerNoSwing
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), songNoSwing),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+      swingTime <- schedulerWithSwing
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), songWithSwing),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+    yield expect.eql(noSwingTime.value, 1.0) and
+      expect.eql(swingTime.value, 1.0)
+
+  // --- Tempo ---
+
+  test("tempo change between notes is picked up"):
+    val song = makeSong(C4.medium.quarter * 2, tempo = tempo120)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 1.0))
+
+  test("slower tempo produces longer schedule time"):
+    val song = makeSong(C4.medium.quarter * 2, tempo = tempo60)
+    makeScheduler(song).flatMap: (scheduler, _, _) =>
+      scheduler
+        .scheduleTrackSequence(
+          TrackIndex(1),
+          trackFor(TrackIndex(1), song),
+          NextNoteTime(0.0),
+          none,
+          absoluteBeatPositionBase = 0.0)
+        .map(result => expect.eql(result.value, 2.0))

--- a/js/src/test/scala/org/soundsofscala/transport/SequencerTest.scala
+++ b/js/src/test/scala/org/soundsofscala/transport/SequencerTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Sounds of Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.soundsofscala.transport
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.Ref
+import org.scalajs.dom.AudioContext
+import org.soundsofscala.instrument.Default.NoSettings
+import org.soundsofscala.instrument.NoInstrument
+import org.soundsofscala.models.*
+import org.soundsofscala.syntax.all.*
+import weaver.SimpleIOSuite
+import org.soundsofscala.TestUtils
+
+object SequencerTest extends SimpleIOSuite:
+
+  given AudioContext = TestUtils.stubAudioContext
+
+  private val testEvent: MusicalEvent = C4.medium.quarter
+
+  private def testSong(tempo: Tempo = Tempo(120)): Song =
+    Song(
+      title = Title("Test Song"),
+      tempo = tempo,
+      mixer = Mixer(NonEmptyList.one(
+        Track(Title("Track 1"), testEvent, NoInstrument[NoSettings](), Playback.OneShot)
+      ))
+    )
+
+  private def makeSequencer(
+      song: Song = testSong()): IO[(Sequencer, Ref[IO, Song])] =
+    for
+      songRef <- Ref.of[IO, Song](song)
+      sequencer <- Sequencer(songRef)
+    yield (sequencer, songRef)
+
+  test("updateSong modifies the song in the Ref"):
+    makeSequencer().flatMap: (sequencer, songRef) =>
+      for
+        _ <- sequencer.updateSong(_.copy(tempo = Tempo(140)))
+        song <- songRef.get
+      yield expect.eql(song.tempo.value, 140.0)
+
+  test("currentBeatPosition starts at zero"):
+    makeSequencer().flatMap: (sequencer, _) =>
+      sequencer.currentBeatPosition.map: beatPosition =>
+        expect.eql(beatPosition.value, 0.0)
+
+  test("toggleClick toggles mute state"):
+    makeSequencer().flatMap: (sequencer, _) =>
+      for
+        first <- sequencer.toggleClickOnOff
+        second <- sequencer.toggleClickOnOff
+      yield expect.eql(first, false) and expect.eql(second, true)
+
+  test("stop is a no-op when not playing"):
+    makeSequencer().flatMap: (sequencer, _) =>
+      sequencer.stop().map(_ => success)
+
+  test("pause captures current beat position"):
+    makeSequencer().flatMap: (sequencer, _) =>
+      for
+        _ <- sequencer.pause()
+        beatPosition <- sequencer.currentBeatPosition
+      yield expect.eql(beatPosition.value, 0.0)
+
+  test("stop after pause resets beat position"):
+    makeSequencer().flatMap: (sequencer, _) =>
+      for
+        _ <- sequencer.pause()
+        _ <- sequencer.stop()
+        beatPosition <- sequencer.currentBeatPosition
+      yield expect.eql(beatPosition.value, 0.0)
+end SequencerTest

--- a/jvm/src/test/scala/org/soundsofscala/TransformMusicalEventsTest.scala
+++ b/jvm/src/test/scala/org/soundsofscala/TransformMusicalEventsTest.scala
@@ -16,18 +16,16 @@
 
 package org.soundsofscala
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
+import cats.effect.IO
 import org.soundsofscala.models.Accidental.*
 import org.soundsofscala.models.DrumVoice.*
 import org.soundsofscala.models.Duration.*
+import weaver.SimpleIOSuite
 
-class TransformMusicalEventsTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks:
+object TransformMusicalEventsTest extends SimpleIOSuite:
 
-  test("testDrumVoiceToString"):
-    Table(
-      ("drumVoice", "expected"),
+  test("drumVoiceToString maps all drum voices"):
+    val mappings = List(
       (Kick, "Doob"),
       (Snare, "Crack"),
       (HiHatClosed, "Tsst"),
@@ -41,12 +39,12 @@ class TransformMusicalEventsTest extends AnyFunSuite with Matchers with TableDri
       (Clap, "Clap"),
       (Cowbell, "Ding"),
       (Tambourine, "Chinka")
-    ).forEvery: (drumVoice, expected) =>
-      TransformMusicalEvents.drumVoiceToString(drumVoice) shouldBe expected
+    )
+    IO.pure(forEach(mappings): (drum, expected) =>
+      expect.same(TransformMusicalEvents.drumVoiceToString(drum), expected))
 
-  test("testDurationToString"):
-    Table(
-      ("duration", "expected"),
+  test("durationToString produces correct lengths"):
+    val mappings = List(
       (Whole, 64 * 3),
       (Half, 32 * 3),
       (Quarter, 16 * 3),
@@ -59,15 +57,28 @@ class TransformMusicalEventsTest extends AnyFunSuite with Matchers with TableDri
       (EighthTriplet, 16),
       (SixteenthTriplet, 8),
       (ThirtySecondTriplet, 4)
-    ).forEvery: (duration, expected) =>
-      TransformMusicalEvents.durationToString(duration, "").length shouldBe expected
+    )
+    IO.pure(forEach(mappings): (duration, expected) =>
+      expect(TransformMusicalEvents.durationToString(duration, "").length == expected))
 
-  test("testAccidentalToString"):
-    Table(
-      ("accidental", "expected"),
+  test("durationToString produces correct lengths for dotted durations"):
+    val mappings = List(
+      (WholeDotted, (64 * 3 * 1.5).toInt),
+      (HalfDotted, (32 * 3 * 1.5).toInt),
+      (QuarterDotted, (16 * 3 * 1.5).toInt),
+      (EighthDotted, (8 * 3 * 1.5).toInt),
+      (SixteenthDotted, (4 * 3 * 1.5).toInt),
+      (ThirtySecondDotted, (2 * 3 * 1.5).toInt)
+    )
+    IO.pure(forEach(mappings): (duration, expected) =>
+      expect(TransformMusicalEvents.durationToString(duration, "").length == expected))
+
+  test("accidentalToString maps all accidentals"):
+    val mappings = List(
       (Sharp, "#"),
       (Flat, "♭"),
       (Natural, "")
-    ).forEvery: (accidental, expected) =>
-      TransformMusicalEvents.accidentalToString(accidental) shouldBe expected
+    )
+    IO.pure(forEach(mappings): (accidental, expected) =>
+      expect.same(TransformMusicalEvents.accidentalToString(accidental), expected))
 end TransformMusicalEventsTest

--- a/jvm/src/test/scala/org/soundsofscala/models/DurationTest.scala
+++ b/jvm/src/test/scala/org/soundsofscala/models/DurationTest.scala
@@ -16,29 +16,74 @@
 
 package org.soundsofscala.models
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
+import cats.effect.IO
 import org.soundsofscala.models.Duration.*
+import weaver.SimpleIOSuite
 
-class DurationTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks:
+object DurationTest extends SimpleIOSuite:
 
-  test("test duration to millisecond conversion") {
-    val table = Table(
-      ("note", "tempo", "expected"),
-      (Whole, Tempo(60), 4),
-      (Half, Tempo(60), 2),
-      (Quarter, Tempo(60), 1),
-      (Eighth, Tempo(60), .5),
-      (Sixteenth, Tempo(60), .250),
-      (ThirtySecond, Tempo(60), 0.125),
-      (SixtyFourth, Tempo(60), 0.0625),
+  test("duration to seconds at 60 BPM"):
+    val mappings = List(
+      (Whole, 4.0),
+      (Half, 2.0),
+      (Quarter, 1.0),
+      (Eighth, 0.5),
+      (Sixteenth, 0.25),
+      (ThirtySecond, 0.125),
+      (SixtyFourth, 0.0625)
+    )
+    IO.pure(forEach(mappings): (duration, expected) =>
+      expect(duration.toSeconds(Tempo(60)) == expected))
+
+  test("duration to seconds at various tempos"):
+    val mappings = List(
       (Whole, Tempo(112), 2.142857142857143),
       (Half, Tempo(117), 1.0256410256410255),
-      (Quarter, Tempo(120), .5),
+      (Quarter, Tempo(120), 0.5),
       (Eighth, Tempo(123), 0.24390243902439024),
       (Sixteenth, Tempo(126), 0.11904761904761904)
     )
-    forAll(table)((note, tempo, seconds) => note.toSeconds(tempo) shouldBe seconds)
+    IO.pure(forEach(mappings): (duration, tempo, expected) =>
+      expect(duration.toSeconds(tempo) == expected))
 
-  }
+  test("duration to beats"):
+    val mappings = List(
+      (Whole, 4.0),
+      (Half, 2.0),
+      (Quarter, 1.0),
+      (Eighth, 0.5),
+      (Sixteenth, 0.25),
+      (ThirtySecond, 0.125),
+      (SixtyFourth, 0.0625)
+    )
+    IO.pure(forEach(mappings): (duration, expected) =>
+      expect(duration.toBeats == expected))
+
+  test("triplet durations are 2/3 of the next larger value"):
+    IO.pure(
+      expect(QuarterTriplet.toBeats == 2.0 / 3.0) and
+        expect(EighthTriplet.toBeats == 1.0 / 3.0) and
+        expect(SixteenthTriplet.toBeats == 0.5 / 3.0))
+
+  test("dotted durations are 1.5x the base"):
+    IO.pure(
+      expect(WholeDotted.toBeats == 6.0) and
+        expect(HalfDotted.toBeats == 3.0) and
+        expect(QuarterDotted.toBeats == 1.5) and
+        expect(EighthDotted.toBeats == 0.75) and
+        expect(SixteenthDotted.toBeats == 0.375))
+
+  test("duration halves with each step"):
+    IO.pure(
+      expect(Whole.toBeats == Half.toBeats * 2) and
+        expect(Half.toBeats == Quarter.toBeats * 2) and
+        expect(Quarter.toBeats == Eighth.toBeats * 2) and
+        expect(Eighth.toBeats == Sixteenth.toBeats * 2) and
+        expect(Sixteenth.toBeats == ThirtySecond.toBeats * 2) and
+        expect(ThirtySecond.toBeats == SixtyFourth.toBeats * 2))
+
+  test("doubling tempo halves duration in seconds"):
+    IO.pure(
+      expect(Quarter.toSeconds(Tempo(120)) == Quarter.toSeconds(Tempo(60)) / 2) and
+        expect(Eighth.toSeconds(Tempo(120)) == Eighth.toSeconds(Tempo(60)) / 2))
+end DurationTest

--- a/jvm/src/test/scala/org/soundsofscala/models/MusicalEventTest.scala
+++ b/jvm/src/test/scala/org/soundsofscala/models/MusicalEventTest.scala
@@ -17,107 +17,238 @@
 package org.soundsofscala.models
 
 import cats.data.NonEmptyList
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
+import cats.effect.IO
 import org.soundsofscala.models.Accidental.*
-import org.soundsofscala.models.AtomicMusicalEvent.Note
+import org.soundsofscala.models.AtomicMusicalEvent.*
 import org.soundsofscala.models.Duration.*
-import org.soundsofscala.models.Octave.*
 import org.soundsofscala.models.Velocity.*
 import org.soundsofscala.syntax.all.*
+import weaver.SimpleIOSuite
 
 import scala.util.Random
 
-class MusicalEventTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks:
+object MusicalEventTest extends SimpleIOSuite:
 
   val c3: Note = Note(Pitch.C, Natural, Quarter, Octave(3), Medium)
 
-  test("Large song doesn't cause a stack overflow"):
+  // --- Combine / Sequence building ---
+
+  test("combine appends sequences"):
+    val result = Sequence(A2, B2) + Sequence(C3, D3)
+    IO.pure(expect.same(result, Sequence(A2, Sequence(B2, Sequence(C3, D3)))))
+
+  test("combine single notes"):
+    val result = A2 + B2
+    IO.pure(expect.same(result, Sequence(A2, B2)))
+
+  test("combine three notes"):
+    val result = A2 + B2 + C3
+    IO.pure(expect.same(result, Sequence(A2, Sequence(B2, C3))))
+
+  // --- Repeat ---
+
+  test("repeat(1) returns self"):
+    val note: MusicalEvent = C4.medium.quarter
+    IO.pure(expect(note.repeat(1).noteCount() == 1))
+
+  test("repeat(4) produces 4 notes"):
+    val result = C4.medium.quarter * 4
+    IO.pure(expect(result.noteCount() == 4))
+
+  test("repeat(2) is same as repeat"):
+    val note: MusicalEvent = A2
+    IO.pure(expect.same(note.repeat(2), note.repeat))
+
+  // --- Note count ---
+
+  test("single note has count 1"):
+    IO.pure(expect(A2.noteCount() == 1))
+
+  test("sequence of 3 has count 3"):
+    val seq = A2 + B2 + C3
+    IO.pure(expect(seq.noteCount() == 3))
+
+  test("large song doesn't cause stack overflow"):
     val notes = Seq[MusicalEvent](A1, B1, C1, D1, E1, F1, G1)
-    Table(
-      ("size", "count"),
-      (1000, 1001),
-      (10000, 10001),
-      (50000, 50001)
-    ).forEvery: (count, expected) =>
+    val sizes = List((1000, 1001), (10000, 10001), (50000, 50001))
+    IO.pure(forEach(sizes): (count, expected) =>
       val testSong =
         (1 to count).foldLeft[MusicalEvent](C2)((acc, _) => acc.+(notes(Random.nextInt(7))))
-      testSong.noteCount() shouldBe expected
-
-  test("testCombineMethod"):
-    Table(
-      ("sequence1", "sequence2", "expected"),
-      (Sequence(A2, B2), Sequence(C3, D3), Sequence(A2, Sequence(B2, Sequence(C3, D3))))
-    ).forEvery: (sequence1, sequence2, expected) =>
-      sequence1 + sequence2 shouldBe expected
-
-  test("Sharp sharpens a Note"):
-
-    Table(
-      ("note", "sharpened"),
-      (c3, C3.sharp)
-    ).forEvery: (note, sharpened) =>
-      note.sharp shouldBe sharpened
-
-  test("Flat flattens a Note"):
-    Table(
-      ("note", "flat"),
-      (c3, C3.flat)
-    ).forEvery: (note, flattened) =>
-      note.flat shouldBe flattened
-
-  test("Chord contains all notes"):
-    println(Cmaj7)
-    Cmaj.noteCount() shouldBe 3
-    Cmaj.notes shouldBe NonEmptyList(
-      HarmonyTiming(C3, TimingOffset(0)),
-      List(HarmonyTiming(E3, TimingOffset(0)), HarmonyTiming(G3, TimingOffset(0))))
-
-  test("Chord contains correct notes"):
-    Dmaj.noteCount() shouldBe 3
-    Dmaj.notes shouldBe NonEmptyList(
-      HarmonyTiming(D3, TimingOffset(0)),
-      List(HarmonyTiming(F3.sharp, TimingOffset(0)), HarmonyTiming(A3, TimingOffset(0))))
-
-  test("4 note Chord contains correct notes"):
-    Cmaj7.noteCount() shouldBe 4
-    Cmaj7.notes shouldBe NonEmptyList(
-      HarmonyTiming(C3, TimingOffset(0)),
-      List(
-        HarmonyTiming(E3, TimingOffset(0)),
-        HarmonyTiming(G3, TimingOffset(0)),
-        HarmonyTiming(B3, TimingOffset(0))))
-
-  test("5 note Chord contains correct notes"):
-    println("Chord")
-    Cmaj9.noteCount() shouldBe 5
-    Cmaj9.notes shouldBe NonEmptyList(
-      HarmonyTiming(C3, TimingOffset(0)),
-      List(
-        HarmonyTiming(E3, TimingOffset(0)),
-        HarmonyTiming(G3, TimingOffset(0)),
-        HarmonyTiming(B3, TimingOffset(0)),
-        HarmonyTiming(D4, TimingOffset(0)))
+      expect(testSong.noteCount() == expected)
     )
 
-  test("testReverseNote"):
-    Table(
-      ("sequence", "expected"),
-      (Sequence(A2, B2), Sequence(B2, A2)),
-      (Sequence(A2, Sequence(B2, C3)), Sequence(C3, Sequence(B2, A2))),
-      (
-        Sequence(A2, Sequence(B2, Sequence(C3, D3))),
-        Sequence(D3, Sequence(C3, Sequence(B2, A2)))),
-      (
-        Sequence(A2, Sequence(B2, Sequence(C3, Sequence(D3, E3)))),
-        Sequence(E3, Sequence(D3, Sequence(C3, Sequence(B2, A2))))),
-      (
-        Sequence(A2, Sequence(B2, Sequence(C3, Sequence(D3, Sequence(E3, F3))))),
-        Sequence(F3, Sequence(E3, Sequence(D3, Sequence(C3, Sequence(B2, A2)))))),
-      (
-        Sequence(A2, Sequence(B2, Sequence(C3, Sequence(D3, Sequence(E3, Sequence(F3, G3)))))),
-        Sequence(G3, Sequence(F3, Sequence(E3, Sequence(D3, Sequence(C3, Sequence(B2, A2)))))))
-    ).forEvery: (sequence, expected) =>
-      sequence.reverse() shouldBe expected
+  // --- Reverse ---
+
+  test("reverse single note returns itself"):
+    IO.pure(expect.same(A2.reverse(), A2))
+
+  test("reverse two-note sequence"):
+    IO.pure(expect.same(Sequence(A2, B2).reverse(), Sequence(B2, A2)))
+
+  test("reverse three-note sequence"):
+    val seq = Sequence(A2, Sequence(B2, C3))
+    IO.pure(expect.same(seq.reverse(), Sequence(C3, Sequence(B2, A2))))
+
+  test("reverse preserves all notes"):
+    val seq = A2 + B2 + C3 + D3 + E3 + F3 + G3
+    IO.pure(expect.same(seq.reverse().reverse(), seq))
+
+  // --- Sharp / Flat ---
+
+  test("sharp sharpens a note"):
+    IO.pure(expect.same(c3.sharp, C3.sharp))
+
+  test("flat flattens a note"):
+    IO.pure(expect.same(c3.flat, C3.flat))
+
+  test("sharp sets accidental to Sharp"):
+    IO.pure(expect(c3.sharp.accidental == Sharp))
+
+  test("flat sets accidental to Flat"):
+    IO.pure(expect(c3.flat.accidental == Flat))
+
+  // --- Duration modifiers ---
+
+  test("duration modifiers change note duration"):
+    val note = C4.medium.quarter
+    IO.pure(
+      expect(note.whole.durationToBeats == 4.0) and
+        expect(note.half.durationToBeats == 2.0) and
+        expect(note.quarter.durationToBeats == 1.0) and
+        expect(note.eighth.durationToBeats == 0.5) and
+        expect(note.sixteenth.durationToBeats == 0.25))
+
+  test("dotted durations are 1.5x the base"):
+    val note = C4.medium.quarter
+    IO.pure(
+      expect(note.halfDotted.durationToBeats == 3.0) and
+        expect(note.quarterDotted.durationToBeats == 1.5) and
+        expect(note.eighthDotted.durationToBeats == 0.75))
+
+  // --- Velocity modifiers ---
+
+  test("velocity modifiers change note velocity"):
+    val note = C4.medium.quarter
+    IO.pure(
+      expect(note.muted.normalizedVelocity == 0.0) and
+        expect(note.soft.normalizedVelocity > 0.0) and
+        expect(note.medium.normalizedVelocity > note.soft.normalizedVelocity) and
+        expect(note.loud.normalizedVelocity > note.medium.normalizedVelocity) and
+        expect(note.onFull.normalizedVelocity == 1.0))
+
+  test("classical velocity names map correctly"):
+    val note = C4.medium.quarter
+    IO.pure(
+      expect(note.ppp.normalizedVelocity == note.softest.normalizedVelocity) and
+        expect(note.ff.normalizedVelocity == note.loud.normalizedVelocity) and
+        expect(note.fff.normalizedVelocity == note.onFull.normalizedVelocity))
+
+  // --- Rest ---
+
+  test("rest has correct duration"):
+    IO.pure(
+      expect(Rest(Quarter).durationToBeats == 1.0) and
+        expect(Rest(Eighth).durationToBeats == 0.5) and
+        expect(Rest(Whole).durationToBeats == 4.0))
+
+  test("rest has zero velocity"):
+    IO.pure(expect(Rest(Quarter).normalizedVelocity == 0.0))
+
+  // --- Chords ---
+
+  test("chord contains all notes"):
+    IO.pure(
+      expect(Cmaj.noteCount() == 3) and
+        expect.same(
+          Cmaj.notes,
+          NonEmptyList(
+            HarmonyTiming(C3, TimingOffset(0)),
+            List(HarmonyTiming(E3, TimingOffset(0)), HarmonyTiming(G3, TimingOffset(0))))))
+
+  test("chord contains correct notes for Dmaj"):
+    IO.pure(
+      expect(Dmaj.noteCount() == 3) and
+        expect.same(
+          Dmaj.notes,
+          NonEmptyList(
+            HarmonyTiming(D3, TimingOffset(0)),
+            List(
+              HarmonyTiming(F3.sharp, TimingOffset(0)),
+              HarmonyTiming(A3, TimingOffset(0))))))
+
+  test("4 note chord contains correct notes"):
+    IO.pure(
+      expect(Cmaj7.noteCount() == 4) and
+        expect.same(
+          Cmaj7.notes,
+          NonEmptyList(
+            HarmonyTiming(C3, TimingOffset(0)),
+            List(
+              HarmonyTiming(E3, TimingOffset(0)),
+              HarmonyTiming(G3, TimingOffset(0)),
+              HarmonyTiming(B3, TimingOffset(0))))
+        ))
+
+  test("5 note chord contains correct notes"):
+    IO.pure(
+      expect(Cmaj9.noteCount() == 5) and
+        expect.same(
+          Cmaj9.notes,
+          NonEmptyList(
+            HarmonyTiming(C3, TimingOffset(0)),
+            List(
+              HarmonyTiming(E3, TimingOffset(0)),
+              HarmonyTiming(G3, TimingOffset(0)),
+              HarmonyTiming(B3, TimingOffset(0)),
+              HarmonyTiming(D4, TimingOffset(0)))
+          )
+        ))
+
+  test("minor chord has flat third"):
+    IO.pure(
+      expect(Cmin.noteCount() == 3) and
+        expect.same(
+          Cmin.notes,
+          NonEmptyList(
+            HarmonyTiming(C3, TimingOffset(0)),
+            List(
+              HarmonyTiming(E3.flat, TimingOffset(0)),
+              HarmonyTiming(G3, TimingOffset(0))))))
+
+  test("chord duration matches root note duration"):
+    val chord = Chord(C3.half, E3, G3)
+    IO.pure(expect(chord.durationToBeats == 2.0))
+
+  // --- DrumStroke ---
+
+  test("drum stroke has correct duration"):
+    val kick = DrumStroke(DrumVoice.Kick, Quarter, OnFull)
+    IO.pure(expect(kick.durationToBeats == 1.0))
+
+  test("drum stroke velocity can be changed"):
+    val kick = DrumStroke(DrumVoice.Kick, Quarter, OnFull)
+    IO.pure(
+      expect(kick.normalizedVelocity == 1.0) and
+        expect(kick.soft.normalizedVelocity < 1.0))
+
+  // --- Pipe operator ---
+
+  test("pipe operator combines same as +"):
+    val a = A2 + B2
+    val b = A2 | B2
+    IO.pure(expect.same(a, b))
+
+  // --- durationToSeconds ---
+
+  test("durationToSeconds at 60 BPM"):
+    IO.pure(
+      expect(C4.medium.quarter.durationToSeconds(Tempo(60)) == 1.0) and
+        expect(C4.medium.half.durationToSeconds(Tempo(60)) == 2.0) and
+        expect(C4.medium.eighth.durationToSeconds(Tempo(60)) == 0.5))
+
+  test("durationToSeconds at 120 BPM"):
+    IO.pure(
+      expect(C4.medium.quarter.durationToSeconds(Tempo(120)) == 0.5) and
+        expect(C4.medium.half.durationToSeconds(Tempo(120)) == 1.0) and
+        expect(C4.medium.whole.durationToSeconds(Tempo(120)) == 2.0))
 end MusicalEventTest

--- a/jvm/src/test/scala/org/soundsofscala/models/PitchTest.scala
+++ b/jvm/src/test/scala/org/soundsofscala/models/PitchTest.scala
@@ -16,48 +16,48 @@
 
 package org.soundsofscala.models
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
+import cats.effect.IO
 import org.soundsofscala.models.AtomicMusicalEvent.*
 import org.soundsofscala.syntax.all.*
+import weaver.SimpleIOSuite
 
-class PitchTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks:
+object PitchTest extends SimpleIOSuite:
 
-  test("Test Calculate Frequency"):
-
-    Table(
-      ("pitch", "frequency"),
-      (Pitch.A, 440),
+  test("calculate frequency for natural pitches"):
+    val mappings = List(
+      (Pitch.A, 440.0),
       (Pitch.B, 493.883),
       (Pitch.C, 261.626),
       (Pitch.D, 293.665),
       (Pitch.E, 329.628),
       (Pitch.F, 349.228),
       (Pitch.G, 391.995)
-    ).forEvery((pitch, frequency) => pitch.calculateFrequency shouldBe frequency)
+    )
+    IO.pure(forEach(mappings): (pitch, frequency) =>
+      expect(pitch.calculateFrequency == frequency))
 
-  test("Test Calculate Frequency with accidentals"):
-    Table(
-      ("note", "frequency"),
-      (A4, 440),
+  test("calculate frequency with accidentals"):
+    val mappings = List(
+      (A4, 440.0),
       (A4.sharp, 466.1637615180899),
       (A4.flat, 415.3046975799451),
       (A8.sharp, 7458.620184289439),
-      (B4, 493.883)).forEvery((note, frequency) => note.frequency shouldBe frequency)
+      (B4, 493.883)
+    )
+    IO.pure(forEach(mappings): (note, frequency) =>
+      expect(note.frequency == frequency))
 
-  test("Frequency is correctly calculated from a Note with Octave"):
-    Table(
-      ("note", "frequency"),
+  test("frequency is correctly calculated from a Note with Octave"):
+    val mappings = List(
       (A0, 27.5),
-      (A1, 55),
-      (A2, 110),
-      (A3, 220),
-      (A4, 440),
-      (A5, 880),
-      (A6, 1760),
-      (A7, 3520),
-      (A8, 7040),
+      (A1, 55.0),
+      (A2, 110.0),
+      (A3, 220.0),
+      (A4, 440.0),
+      (A5, 880.0),
+      (A6, 1760.0),
+      (A7, 3520.0),
+      (A8, 7040.0),
       (B4, 493.883),
       (C4, 261.626),
       (D4, 293.665),
@@ -67,5 +67,21 @@ class PitchTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks
       (C8, 4186.016),
       (D8, 4698.64),
       (E8, 5274.048)
-    ).forEvery((note, frequency) => note.frequency shouldBe frequency)
+    )
+    IO.pure(forEach(mappings): (note, frequency) =>
+      expect(note.frequency == frequency))
+
+  test("octave doubling: each octave doubles frequency"):
+    IO.pure(
+      expect(A1.frequency == A0.frequency * 2) and
+        expect(A2.frequency == A1.frequency * 2) and
+        expect(A4.frequency == A3.frequency * 2))
+
+  test("sharp raises frequency by one semitone"):
+    val ratio = Math.pow(2, 1.0 / 12)
+    IO.pure(expect(A4.sharp.frequency == A4.frequency * ratio))
+
+  test("flat lowers frequency by one semitone"):
+    val ratio = Math.pow(2, 1.0 / 12)
+    IO.pure(expect(A4.flat.frequency == A4.frequency / ratio))
 end PitchTest

--- a/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/MusicalEvent.scala
@@ -51,6 +51,15 @@ sealed trait MusicalEvent:
             case _ => acc + 1
     loop(0, this)
 
+  def totalDurationInBeats: Double =
+    @tailrec
+    def loop(event: MusicalEvent, acc: Double): Double =
+      event match
+        case sequence: Sequence =>
+          loop(sequence.tail, acc + sequence.head.durationToBeats)
+        case atomic: AtomicMusicalEvent => acc + atomic.durationToBeats
+    loop(this, 0.0)
+
   def repeat(repetitions: Int): MusicalEvent =
     if repetitions === 1 then this
     else

--- a/shared/src/main/scala/org/soundsofscala/models/Types.scala
+++ b/shared/src/main/scala/org/soundsofscala/models/Types.scala
@@ -71,6 +71,7 @@ object TrackIndex extends Newtype[Int] with CanBeOrdered[Int]
 type SwingOffset = SwingOffset.Type
 object SwingOffset extends Newtype[Double]:
   def compensation(swingOffset: Double): SwingOffset = SwingOffset(-swingOffset)
+  def none: SwingOffset = SwingOffset(0.0)
 
 final case class Swing(amount: SwingAmount, resolution: SwingResolution)
 


### PR DESCRIPTION
## Refactor Scheduler Architecture and Update Documentation

### Scheduler Refactoring

#### Extracted `TrackScheduler` from `NoteScheduler` (new file)

The `NoteScheduler` had swollen and become confusing by progressively adding new features i.e Looping, Resume playback, Swing etc..
I ended up managing track lifecycle (loop/one-shot, resume position) and scheduling individual notes. These are now split:

- **`TrackScheduler`** owns track lifecycle: loop iteration, one-shot termination, resolving where to resume in a looped pattern, and the recursive loop that chains pattern repeats. Uses a named tuple return from `resolveLoopPlaybackPosition` for clarity.
- **`NoteScheduler`** is now purely responsible for walking through a `MusicalEvent` note by note, scheduling each against the `AudioContext` timeline.

#### Refactored `Sequencer` into trait + private impl

`Sequencer` is now a public trait with a private `SequencerImpl` class behind the `Sequencer.apply` companion factory. This clarifies the public API (`play`, `stop`, `pause`, `updateSong`, `currentBeatPosition`, `toggleClickOnOff`, `startPlaybackFromBeat`) and hides internal state. `LookAhead` and `ScheduleWindow` are now configurable constructor parameters.

#### `NoteScheduler` readability improvements

- Extracted `calculateNextNoteTime` method that owns the swing offset calculation and returns a named tuple `(nextNoteTime, swingCompensation)`
- Extracted `updateBeatPositionTimeline` method for the click track beat position update
- Converted `>>` chains to for comprehensions in `playNextNote`
- Renamed for clarity:
  - `adjustedNoteTime` → `nextNoteTime`
  - `swingCompensation` → `previousNoteSwingCompensation`
  - `incrementBeatPosition` → `addNoteDurationToBeatPosition`
  - `nextNextNoteTime` → `followingNoteTime`
  - `locatePlaybackPosition` → `locatePositionToStartPlayback`
  - `adjustNoteTimeForBeatOffset` → `alignNoteTimeToActualBeatPosition`

#### Model improvements

- `PlaybackLocation` moved from `NoteScheduler` to `Track.scala` as a top level case class
- `resolveTrack` extracted as an extension method on `TrackIndex` in the `Track` companion object
- `totalDurationInBeats` moved from a private `NoteScheduler` method to a public method on `MusicalEvent`
- Added `SwingOffset.none` factory

#### Click track resolution increased to 16th notes

The click track pattern changed from `C4.medium.eighth * 8` to `(C4.medium.sixteenth + r16) * 8`. This gives the `beatPositionRef` 16th note resolution (0.25 beat increments) for more accurate pause/resume positioning across tracks with different subdivisions.

---

### New Tests

- Essentially introduced some much needed tests to validate changes going forward.
- Migrated Test framework to Weaver.
- **`NoteSchedulerTest`** : 16 tests covering basic scheduling at different tempos, mixed durations, rests, non-zero start times, beat position tracking for click vs non-click tracks, beat position base offsets, live pattern updates, resume from beat position, swing offsets, and tempo changes.
- **`SequencerTest`** (89 lines): 6 tests covering `updateSong`, initial beat position, click toggle, stop when not playing, pause, and stop after pause.
- **`TestUtils`**: Centralized `stubAudioContext` builder so `asInstanceOf[AudioContext]` only appears once.

---

### Documentation Overhaul

- **Getting Started**: Added dependency snippet, `SimpleAudioPlayer` section, "Why a Ref?" explanation, recommended Tyrian (Cats Effect based) and Laminar as project scaffolding options
- **Instruments README**: Complete rewrite listing all current instruments (Sampler, ScalaSynth, PianoSynth, ViolinSynth, QuirkyFilterSynth, Simple80sDrumMachine) with descriptions
- **Sampler**: Full writeup covering Johanna Odersky's GSoC project, built in sample sets, custom sample loading, and example songs (`ExampleSong1`, `ExampleSongSampler`)
- **PianoSynth**: Fleshed out with wavetable oscillator details, creation pattern, and multi track usage example
- **Simple80sDrumMachine**: Renamed from SimpleDrumMachine to match the source code class name
- **Deleted stale pages**: Removed `SineSynth.md` and `SawtoothSynth.md` (no corresponding source code)
- **Music DSL docs**: Fixed `AtomicMusicalEvent` typo, corrected `Octave` type, updated `Velocity` list to be complete, fixed `Swing` constructor, fixed `ExampleSong0` → `ExampleSong1`, added `using` clause to `Track`, removed "yet to be implemented" for swing, fixed `MusicalEvent` nesting in code block
- **Navigation**: Reordered instruments to Sampler → PianoSynth → ScalaSynth → Simple80sDrumMachine, fixed all next step links, fixed broken localhost link in docs README
- **Version bump**: 0.8.1 → 0.8.2 in docs and repo README
- **Repo README**: Added virtualmattondrums.com link

---

### No Breaking Changes

All changes are internal refactors. The public API surface is unchanged apart from `Sequencer` becoming a trait (which is source compatible for all callers using `Sequencer.apply`). `toggleClick` was renamed to `toggleClickOnOff`.
